### PR TITLE
Add interactive run selection to quedex tui

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -959,11 +959,12 @@ fn print_run_selection_ui(runs: &[RunInfo], selected: usize) {
         for (idx, run) in &active_runs {
             let marker = if *idx == selected { ">" } else { " " };
             let reason = run.active_reason.as_deref().unwrap_or("");
+            let short_id: String = run.state.run_id.chars().take(8).collect();
             println!(
                 "{} [{:?}] {}  {}  ({})",
                 marker,
                 run.state.status,
-                &run.state.run_id[..8],
+                short_id,
                 run.state.run_name,
                 reason
             );
@@ -975,11 +976,12 @@ fn print_run_selection_ui(runs: &[RunInfo], selected: usize) {
         println!("Recent:");
         for (idx, run) in &inactive_runs {
             let marker = if *idx == selected { ">" } else { " " };
+            let short_id: String = run.state.run_id.chars().take(8).collect();
             println!(
                 "{} [{:?}] {}  {}",
                 marker,
                 run.state.status,
-                &run.state.run_id[..8],
+                short_id,
                 run.state.run_name
             );
         }


### PR DESCRIPTION
## 概要
`quedex tui` をIDなしで実行した時に、現在のrunをインタラクティブに選択してTUIを起動できるようにする機能を追加。

## 変更内容
- `RunInfo` 構造体と `list_runs_with_activity` 関数を追加し、各runのアクティブ状態を判定
- `select_run_interactive` 関数を追加し、crossterm を使ったインタラクティブな選択UIを実装
- `handle_tui` 関数を修正し、新しいフローを適用：
  - run_id指定あり → 従来通りTUI起動
  - runが0件 → "no runs found" で終了
  - アクティブrunが1件のみ → 自動選択してTUI起動
  - 複数runあり → インタラクティブ選択UIを表示

## 選択UIイメージ
```
Select a run to monitor:

Running:
> [Running] abc123  my-plan  (pid 12345)
  [Running] def456  another  (pid 67890)

Recent:
  [Completed] xyz789  test-plan
  [Failed] ghi012  failed-plan

[↑↓] Select  [Enter] Open TUI  [q] Cancel
```

## テスト方法
- `quedex tui` をrunなしで実行 → "no runs found" 表示
- `quedex run plan.json &` で1件起動 → `quedex tui` で自動選択
- 複数run起動 → `quedex tui` で選択UI表示、↑↓/j/k/Enter/qキーの動作確認