### PR TITLE
feat: opencode ランナーのサポートを追加

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ use cli::{Cli, Commands, GlobalOptions, RecoveryOptions};
 use quedex::plan::{Plan, PlanFormat, Task};
 use quedex::runner::claude_code::ClaudeCodeRunner;
 use quedex::runner::codex::CodexRunner;
+use quedex::runner::opencode::OpencodeRunner;
 use quedex::runner::{ChildHandle, RunContext, Runner};
 use quedex::scheduler::{
     ScheduleReport, Scheduler, SchedulerOptions, TaskRecord, TaskResult, TaskRunner, TaskSpec,
@@ -135,6 +136,16 @@ async fn handle_run(
         matches!(task.kind.as_deref(), Some("claude_code")) || task.claude_code.is_some()
     }) {
         if let Err(err) = check_claude_code_available() {
+            eprintln!("environment error: {err}");
+            return Ok(4);
+        }
+    }
+
+    #[allow(clippy::collapsible_if)]
+    if plan.tasks.iter().any(|task| {
+        matches!(task.kind.as_deref(), Some("opencode")) || task.opencode.is_some()
+    }) {
+        if let Err(err) = check_opencode_available() {
             eprintln!("environment error: {err}");
             return Ok(4);
         }
@@ -340,6 +351,16 @@ async fn handle_start(
         }
     }
 
+    #[allow(clippy::collapsible_if)]
+    if plan.tasks.iter().any(|task| {
+        matches!(task.kind.as_deref(), Some("opencode")) || task.opencode.is_some()
+    }) {
+        if let Err(err) = check_opencode_available() {
+            eprintln!("environment error: {err}");
+            return Ok(4);
+        }
+    }
+
     let plan_path = if recovery.resume {
         snapshot_path
     } else {
@@ -469,6 +490,9 @@ async fn handle_retry(global: &GlobalOptions, run_id: &str, task_id: &str) -> Re
     }
     if matches!(task.kind.as_deref(), Some("claude_code")) || task.claude_code.is_some() {
         check_claude_code_available()?;
+    }
+    if matches!(task.kind.as_deref(), Some("opencode")) || task.opencode.is_some() {
+        check_opencode_available()?;
     }
 
     let mut state = read_state(&store_root, run_id)?;
@@ -868,6 +892,18 @@ fn check_claude_code_available() -> Result<()> {
     match status {
         Ok(_) => Ok(()),
         Err(err) => Err(anyhow!(err).context("claude not found")),
+    }
+}
+
+fn check_opencode_available() -> Result<()> {
+    let status = std::process::Command::new("opencode")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+    match status {
+        Ok(_) => Ok(()),
+        Err(err) => Err(anyhow!(err).context("opencode not found")),
     }
 }
 
@@ -1526,6 +1562,7 @@ struct PlanTaskRunner {
     cancel: CancelHandle,
     codex: CodexRunner,
     claude_code: ClaudeCodeRunner,
+    opencode: OpencodeRunner,
     default_timeout_sec: Option<u64>,
 }
 
@@ -1544,6 +1581,7 @@ impl PlanTaskRunner {
             cancel,
             codex: CodexRunner::new(),
             claude_code: ClaudeCodeRunner::new(),
+            opencode: OpencodeRunner::new(),
             default_timeout_sec,
         }
     }
@@ -1559,6 +1597,7 @@ impl TaskRunner for PlanTaskRunner {
         let cancel = self.cancel.clone();
         let codex = self.codex;
         let claude_code = self.claude_code;
+        let opencode = self.opencode;
         let default_timeout_sec = self.default_timeout_sec;
 
         Box::pin(async move {
@@ -1573,8 +1612,10 @@ impl TaskRunner for PlanTaskRunner {
 
             let runner: &dyn Runner = if task.codex.is_some() {
                 &codex
-            } else {
+            } else if task.claude_code.is_some() {
                 &claude_code
+            } else {
+                &opencode
             };
 
             let child = match runner.spawn(task, &ctx) {

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -71,6 +71,15 @@ pub struct ClaudeCodeConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpencodeConfig {
+    pub prompt: String,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default = "default_json")]
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Task {
     pub id: String,
     #[serde(default)]
@@ -88,6 +97,8 @@ pub struct Task {
     pub codex: Option<CodexConfig>,
     #[serde(default)]
     pub claude_code: Option<ClaudeCodeConfig>,
+    #[serde(default)]
+    pub opencode: Option<OpencodeConfig>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -127,13 +138,13 @@ impl Plan {
             if !seen.insert(task.id.clone()) {
                 bail!("duplicate task id {}", task.id);
             }
-            let runner_count = [task.codex.is_some(), task.claude_code.is_some()]
+            let runner_count = [task.codex.is_some(), task.claude_code.is_some(), task.opencode.is_some()]
                 .iter()
                 .filter(|&&x| x)
                 .count();
             if runner_count > 1 {
                 bail!(
-                    "task {} has multiple runner configs (only one of codex or claude_code allowed)",
+                    "task {} has multiple runner configs (only one of codex, claude_code, or opencode allowed)",
                     task.id
                 );
             }
@@ -150,6 +161,11 @@ impl Plan {
                     "claude_code" => {
                         if task.claude_code.is_none() {
                             bail!("task {} kind=claude_code without claude_code config", task.id);
+                        }
+                    }
+                    "opencode" => {
+                        if task.opencode.is_none() {
+                            bail!("task {} kind=opencode without opencode config", task.id);
                         }
                     }
                     _ => bail!("task {} has unknown kind {}", task.id, kind),
@@ -170,6 +186,11 @@ impl Plan {
                 && claude_code.prompt.trim().is_empty()
             {
                 bail!("task {} claude_code.prompt is empty", task.id);
+            }
+            if let Some(opencode) = task.opencode.as_ref()
+                && opencode.prompt.trim().is_empty()
+            {
+                bail!("task {} opencode.prompt is empty", task.id);
             }
             for dep in &task.deps {
                 if dep == &task.id {

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -10,6 +10,7 @@ use crate::store::Store;
 
 pub mod claude_code;
 pub mod codex;
+pub mod opencode;
 
 pub trait Runner {
     fn spawn(&self, task: &Task, ctx: &RunContext) -> Result<ChildHandle>;

--- a/src/runner/opencode.rs
+++ b/src/runner/opencode.rs
@@ -1,0 +1,69 @@
+use std::process::{Command, Stdio};
+
+use anyhow::{Context, Result};
+
+use crate::plan::Task;
+use crate::runner::{ChildHandle, RunContext, Runner};
+use crate::store::LogStream;
+
+#[derive(Clone, Copy)]
+pub struct OpencodeRunner;
+
+impl OpencodeRunner {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for OpencodeRunner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Runner for OpencodeRunner {
+    fn spawn(&self, task: &Task, ctx: &RunContext) -> Result<ChildHandle> {
+        let config = task
+            .opencode
+            .as_ref()
+            .context("opencode config missing")?;
+
+        let stdout_path = ctx.store.log_path(&task.id, LogStream::Stdout);
+        let stderr_path = ctx.store.log_path(&task.id, LogStream::Stderr);
+        let stdout = ctx
+            .store
+            .open_log(&task.id, LogStream::Stdout)
+            .context("open stdout log")?;
+        let stderr = ctx
+            .store
+            .open_log(&task.id, LogStream::Stderr)
+            .context("open stderr log")?;
+
+        let mut cmd = Command::new("opencode");
+        cmd.arg("run");
+
+        // Model selection (optional)
+        if let Some(model) = config.model.as_ref() {
+            cmd.arg("-m").arg(model);
+        }
+
+        // Output format
+        if config.json {
+            cmd.arg("--format").arg("json");
+        }
+
+        // Prompt as positional argument
+        cmd.arg(&config.prompt);
+
+        let child = cmd
+            .current_dir(&ctx.cwd)
+            .envs(&ctx.env)
+            .env("PATH", std::env::var("PATH").unwrap_or_default())
+            .stdout(Stdio::from(stdout))
+            .stderr(Stdio::from(stderr))
+            .spawn()
+            .context("spawn opencode")?;
+
+        Ok(ChildHandle::new(child, stdout_path, stderr_path))
+    }
+}

--- a/tests/plan_validation_tests.rs
+++ b/tests/plan_validation_tests.rs
@@ -1,4 +1,4 @@
-use quedex::plan::{ClaudeCodeConfig, CodexConfig, Plan, RunConfig, Task, TaskMode};
+use quedex::plan::{ClaudeCodeConfig, CodexConfig, OpencodeConfig, Plan, RunConfig, Task, TaskMode};
 
 fn codex_task(id: &str, deps: Vec<&str>) -> Task {
     Task {
@@ -18,6 +18,26 @@ fn codex_task(id: &str, deps: Vec<&str>) -> Task {
             json: true,
         }),
         claude_code: None,
+        opencode: None,
+    }
+}
+
+fn opencode_task(id: &str, deps: Vec<&str>) -> Task {
+    Task {
+        id: id.to_string(),
+        title: None,
+        mode: TaskMode::Implement,
+        deps: deps.into_iter().map(|dep| dep.to_string()).collect(),
+        locks: vec![],
+        timeout_sec: None,
+        kind: None,
+        codex: None,
+        claude_code: None,
+        opencode: Some(OpencodeConfig {
+            prompt: "test prompt".to_string(),
+            model: None,
+            json: true,
+        }),
     }
 }
 
@@ -75,6 +95,7 @@ fn plan_rejects_empty_codex_prompt() {
             json: true,
         }),
         claude_code: None,
+        opencode: None,
     };
 
     let plan = plan_with_tasks(vec![task]);
@@ -97,6 +118,7 @@ fn plan_rejects_empty_claude_code_prompt() {
             model: None,
             json: true,
         }),
+        opencode: None,
     };
 
     let plan = plan_with_tasks(vec![task]);
@@ -126,6 +148,7 @@ fn plan_rejects_multiple_runner_configs() {
             model: None,
             json: true,
         }),
+        opencode: None,
     };
 
     let plan = plan_with_tasks(vec![task]);
@@ -148,6 +171,7 @@ fn plan_accepts_valid_claude_code_task() {
             model: Some("sonnet".to_string()),
             json: true,
         }),
+        opencode: None,
     };
 
     let plan = plan_with_tasks(vec![task]);
@@ -173,8 +197,108 @@ fn plan_rejects_kind_mismatch_claude_code() {
             json: true,
         }),
         claude_code: None,
+        opencode: None,
     };
 
     let plan = plan_with_tasks(vec![task]);
     assert_validation_error(plan, "kind=claude_code without claude_code config");
+}
+
+#[test]
+fn plan_rejects_empty_opencode_prompt() {
+    let task = Task {
+        id: "opencode".to_string(),
+        title: None,
+        mode: TaskMode::Implement,
+        deps: vec![],
+        locks: vec![],
+        timeout_sec: None,
+        kind: None,
+        codex: None,
+        claude_code: None,
+        opencode: Some(OpencodeConfig {
+            prompt: " ".to_string(),
+            model: None,
+            json: true,
+        }),
+    };
+
+    let plan = plan_with_tasks(vec![task]);
+    assert_validation_error(plan, "opencode.prompt is empty");
+}
+
+#[test]
+fn plan_accepts_valid_opencode_task() {
+    let task = Task {
+        id: "opencode".to_string(),
+        title: None,
+        mode: TaskMode::Implement,
+        deps: vec![],
+        locks: vec![],
+        timeout_sec: None,
+        kind: Some("opencode".to_string()),
+        codex: None,
+        claude_code: None,
+        opencode: Some(OpencodeConfig {
+            prompt: "implement feature".to_string(),
+            model: Some("anthropic/claude-sonnet".to_string()),
+            json: true,
+        }),
+    };
+
+    let plan = plan_with_tasks(vec![task]);
+    assert!(plan.validate().is_ok());
+}
+
+#[test]
+fn plan_rejects_kind_mismatch_opencode() {
+    let task = Task {
+        id: "mismatch".to_string(),
+        title: None,
+        mode: TaskMode::Implement,
+        deps: vec![],
+        locks: vec![],
+        timeout_sec: None,
+        kind: Some("opencode".to_string()),
+        codex: Some(CodexConfig {
+            prompt: "test".to_string(),
+            output_last_message: None,
+            verify_after: false,
+            sandbox: None,
+            ask_for_approval: None,
+            json: true,
+        }),
+        claude_code: None,
+        opencode: None,
+    };
+
+    let plan = plan_with_tasks(vec![task]);
+    assert_validation_error(plan, "kind=opencode without opencode config");
+}
+
+#[test]
+fn plan_rejects_multiple_runner_configs_with_opencode() {
+    let task = Task {
+        id: "multi".to_string(),
+        title: None,
+        mode: TaskMode::Implement,
+        deps: vec![],
+        locks: vec![],
+        timeout_sec: None,
+        kind: None,
+        codex: None,
+        claude_code: Some(ClaudeCodeConfig {
+            prompt: "test".to_string(),
+            model: None,
+            json: true,
+        }),
+        opencode: Some(OpencodeConfig {
+            prompt: "test".to_string(),
+            model: None,
+            json: true,
+        }),
+    };
+
+    let plan = plan_with_tasks(vec![task]);
+    assert_validation_error(plan, "multiple runner configs");
 }


### PR DESCRIPTION
## 概要
OpenCode CLIを新しいランナーオプションとして追加し、codex/claude_codeと並んで使用可能にする。

## 変更内容
- `src/plan.rs`: `OpencodeConfig`構造体を追加（prompt, model, jsonフィールド）
- `src/runner/opencode.rs`: `OpencodeRunner`を新規作成
- `src/runner/mod.rs`: opencodeモジュールをエクスポート
- `src/main.rs`: ランナー統合（環境確認、PlanTaskRunner、選択ロジック）
- `tests/plan_validation_tests.rs`: opencodeタスクのバリデーションテスト追加

## 使用例
```json
{
  "version": 1,
  "tasks": [
    {
      "id": "research",
      "mode": "research",
      "opencode": {
        "prompt": "プロジェクト構造を調査",
        "model": "anthropic/claude-sonnet",
        "json": true
      }
    }
  ]
}
```

## テスト方法
- `cargo build` - ビルド確認
- `cargo test` - 全18テスト通過
- `cargo clippy` - 警告なし