### PR TITLE
feat: retryコマンドでSkippedタスクも対象にする

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -538,9 +538,9 @@ async fn handle_retry(
             "task {task_id} not found in state for run {run_id}"
         ));
     };
-    if !matches!(task_state.status, TaskStatus::Failed | TaskStatus::Canceled) {
+    if !matches!(task_state.status, TaskStatus::Failed | TaskStatus::Canceled | TaskStatus::Skipped) {
         return Err(anyhow!(
-            "task {} must be Failed or Canceled to retry (current: {:?})",
+            "task {} must be Failed, Canceled or Skipped to retry (current: {:?})",
             task_id,
             task_state.status
         ));


### PR DESCRIPTION
## 概要
`retry` コマンドの対象ステータスに `Skipped` を追加し、fail_fast等でスキップされたタスクも再試行可能にする。

## 変更内容
- `handle_retry` 関数で `TaskStatus::Skipped` を対象ステータスに追加
- エラーメッセージを「Failed, Canceled or Skipped」に更新

## テスト方法
- `cargo build` でビルドが通ることを確認 ✅
- `cargo test` でテストが通ることを確認 ✅
- fail_fastモードでタスクを実行し、Skippedになったタスクを `quedex retry <run_id> <task_id>` でretryできることを確認