### PR TITLE
feat: quedex機能追加（init, dry-run, verbose, history, retry, schema）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,6 +673,7 @@ dependencies = [
  "notify",
  "petgraph",
  "ratatui",
+ "schemars",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -809,6 +816,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,6 +869,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ crossterm = "0.28"
 notify = "6"
 petgraph = "0.6"
 ratatui = "0.26"
+schemars = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,6 +22,9 @@ pub struct GlobalOptions {
     pub fail_fast: bool,
     #[arg(long = "no-fail-fast", action = ArgAction::SetTrue, conflicts_with = "fail_fast")]
     pub no_fail_fast: bool,
+    /// Enable verbose output for debugging
+    #[arg(long, short = 'v', action = ArgAction::SetTrue, global = true)]
+    pub verbose: bool,
 }
 
 impl GlobalOptions {
@@ -36,6 +39,16 @@ impl GlobalOptions {
 
 #[derive(Debug, Subcommand)]
 pub enum Commands {
+    /// Initialize a new plan.json template
+    Init {
+        /// Output file path (default: plan.json)
+        #[arg(short = 'o', long, value_name = "path")]
+        output: Option<PathBuf>,
+        /// Overwrite existing file
+        #[arg(long, action = ArgAction::SetTrue)]
+        force: bool,
+    },
+    /// Run a plan (blocking)
     Run {
         plan: String,
         #[command(flatten)]
@@ -44,7 +57,11 @@ pub enum Commands {
         run_id: Option<String>,
         #[arg(long, hide = true)]
         base_dir: Option<PathBuf>,
+        /// Show execution plan without running tasks
+        #[arg(long, action = ArgAction::SetTrue)]
+        dry_run: bool,
     },
+    /// Start a plan in background
     Start {
         plan: String,
         #[command(flatten)]
@@ -52,14 +69,17 @@ pub enum Commands {
         #[arg(long, hide = true)]
         run_id: Option<String>,
     },
+    /// Show run status
     Status {
         run_id: Option<String>,
         #[arg(long)]
         json: bool,
     },
+    /// Open TUI monitor
     Tui {
         run_id: Option<String>,
     },
+    /// Show task logs
     Logs {
         run_id: String,
         task_id: String,
@@ -68,27 +88,49 @@ pub enum Commands {
         #[arg(long)]
         stderr: bool,
     },
+    /// Retry a failed task
     Retry {
         run_id: String,
         task_id: String,
         #[arg(long, help = "Reload plan.json from the run directory before retrying")]
         reload_plan: bool,
     },
+    /// Cancel a running task or run
     Cancel {
         run_id: String,
         task_id: Option<String>,
     },
+    /// Clean up run directories
     Clean {
         run_id: Option<String>,
         #[arg(long, action = ArgAction::SetTrue)]
         all: bool,
     },
+    /// Show task dependency graph
     Graph {
         target: String,
         #[arg(long, conflicts_with = "ascii")]
         mermaid: bool,
         #[arg(long, conflicts_with = "mermaid")]
         ascii: bool,
+    },
+    /// Show execution history
+    History {
+        /// Maximum number of entries to show
+        #[arg(long, short = 'n', default_value = "10")]
+        limit: usize,
+        /// Show all history entries
+        #[arg(long, action = ArgAction::SetTrue, conflicts_with = "limit")]
+        all: bool,
+        /// Output in JSON format
+        #[arg(long)]
+        json: bool,
+    },
+    /// Output JSON schema for plan.json
+    Schema {
+        /// Output file path (default: stdout)
+        #[arg(short = 'o', long, value_name = "path")]
+        output: Option<PathBuf>,
     },
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,12 +50,20 @@ async fn main() {
 
 async fn dispatch(cli: Cli) -> Result<i32> {
     match cli.command {
+        Commands::Init { output, force } => handle_init(&cli.global, output, force),
         Commands::Run {
             plan,
             recovery,
             run_id,
             base_dir,
-        } => handle_run(&cli.global, &plan, recovery, run_id, base_dir).await,
+            dry_run,
+        } => {
+            if dry_run {
+                handle_dry_run(&cli.global, &plan)
+            } else {
+                handle_run(&cli.global, &plan, recovery, run_id, base_dir).await
+            }
+        }
         Commands::Start {
             plan,
             recovery,
@@ -81,7 +89,188 @@ async fn dispatch(cli: Cli) -> Result<i32> {
             mermaid,
             ascii,
         } => handle_graph(&cli.global, &target, mermaid, ascii),
+        Commands::History { limit, all, json } => handle_history(&cli.global, limit, all, json),
+        Commands::Schema { output } => handle_schema(output),
     }
+}
+
+fn handle_init(global: &GlobalOptions, output: Option<PathBuf>, force: bool) -> Result<i32> {
+    let output_path = output.unwrap_or_else(|| PathBuf::from("plan.json"));
+
+    if output_path.exists() && !force {
+        return Err(anyhow!(
+            "file {} already exists (use --force to overwrite)",
+            output_path.display()
+        ));
+    }
+
+    if global.verbose {
+        eprintln!("[verbose] Creating plan template at {}", output_path.display());
+    }
+
+    let template = r#"{
+  "version": 1,
+  "run": {
+    "name": "my-plan",
+    "max_concurrency": 2,
+    "fail_fast": true
+  },
+  "tasks": [
+    {
+      "id": "task-1",
+      "mode": "implement",
+      "deps": [],
+      "codex": {
+        "prompt": "Describe what this task should do"
+      }
+    }
+  ]
+}
+"#;
+
+    fs::write(&output_path, template)
+        .with_context(|| format!("write plan template to {}", output_path.display()))?;
+
+    println!("Created {}", output_path.display());
+    Ok(0)
+}
+
+fn handle_dry_run(global: &GlobalOptions, plan_arg: &str) -> Result<i32> {
+    let (plan, _plan_base_dir) = load_plan(plan_arg)?;
+
+    if let Err(err) = plan.validate() {
+        eprintln!("plan validation error: {err}");
+        return Ok(3);
+    }
+
+    println!("Dry run mode - no tasks will be executed");
+    println!();
+    println!("Plan: {}", plan.run.name.as_deref().unwrap_or("(unnamed)"));
+    println!("Tasks: {}", plan.tasks.len());
+
+    if global.verbose {
+        eprintln!("[verbose] Max concurrency: {:?}", plan.run.max_concurrency);
+        eprintln!("[verbose] Fail fast: {:?}", plan.run.fail_fast);
+    }
+
+    // Build dependency graph to determine execution order
+    let mut in_degree: HashMap<&str, usize> = HashMap::new();
+    let mut dependents: HashMap<&str, Vec<&str>> = HashMap::new();
+
+    for task in &plan.tasks {
+        in_degree.entry(task.id.as_str()).or_insert(0);
+        for dep in &task.deps {
+            dependents
+                .entry(dep.as_str())
+                .or_default()
+                .push(task.id.as_str());
+            *in_degree.entry(task.id.as_str()).or_insert(0) += 1;
+        }
+    }
+
+    // Topological sort using Kahn's algorithm
+    let mut queue: Vec<&str> = in_degree
+        .iter()
+        .filter(|(_, deg)| **deg == 0)
+        .map(|(id, _)| *id)
+        .collect();
+    queue.sort(); // Sort for deterministic output
+
+    let mut order = Vec::new();
+    while let Some(task_id) = queue.pop() {
+        order.push(task_id);
+        if let Some(deps) = dependents.get(task_id) {
+            for &dep in deps {
+                if let Some(deg) = in_degree.get_mut(dep) {
+                    *deg -= 1;
+                    if *deg == 0 {
+                        queue.push(dep);
+                        queue.sort();
+                    }
+                }
+            }
+        }
+    }
+
+    println!();
+    println!("Execution order:");
+    for (i, task_id) in order.iter().enumerate() {
+        let task = plan.tasks.iter().find(|t| t.id == *task_id).unwrap();
+        let deps_str = if task.deps.is_empty() {
+            "none".to_string()
+        } else {
+            task.deps.join(", ")
+        };
+        let runner = if task.codex.is_some() {
+            "codex"
+        } else if task.claude_code.is_some() {
+            "claude_code"
+        } else {
+            "opencode"
+        };
+        println!("  {}. {} (deps: {}) [{}]", i + 1, task_id, deps_str, runner);
+    }
+
+    Ok(0)
+}
+
+fn handle_history(global: &GlobalOptions, limit: usize, all: bool, json: bool) -> Result<i32> {
+    let store_root = resolve_store_path(global.store.as_ref())?;
+
+    if global.verbose {
+        eprintln!("[verbose] Reading history from {}", store_root.display());
+    }
+
+    let mut states = list_states(&store_root)?;
+    states.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+
+    let display_limit = if all { states.len() } else { limit };
+    let states: Vec<_> = states.into_iter().take(display_limit).collect();
+
+    if json {
+        let text = serde_json::to_string_pretty(&states)?;
+        println!("{text}");
+    } else {
+        if states.is_empty() {
+            println!("No execution history found");
+            return Ok(0);
+        }
+        println!(
+            "{:<36} {:<10} {:<20} {:<20} name",
+            "run_id", "status", "started_at", "completed_at"
+        );
+        for state in &states {
+            let completed_str = state
+                .completed_at
+                .map(|t| t.format("%Y-%m-%d %H:%M:%S").to_string())
+                .unwrap_or_else(|| "-".to_string());
+            println!(
+                "{:<36} {:<10} {:<20} {:<20} {}",
+                state.run_id,
+                format!("{:?}", state.status),
+                state.started_at.format("%Y-%m-%d %H:%M:%S"),
+                completed_str,
+                state.run_name
+            );
+        }
+    }
+
+    Ok(0)
+}
+
+fn handle_schema(output: Option<PathBuf>) -> Result<i32> {
+    let schema = quedex::plan::plan_json_schema();
+    let schema_json = serde_json::to_string_pretty(&schema)?;
+
+    if let Some(output_path) = output {
+        fs::write(&output_path, &schema_json)
+            .with_context(|| format!("write schema to {}", output_path.display()))?;
+        println!("Schema written to {}", output_path.display());
+    } else {
+        println!("{schema_json}");
+    }
+
+    Ok(0)
 }
 
 async fn handle_run(
@@ -1661,6 +1850,9 @@ impl TaskRunner for PlanTaskRunner {
             };
 
             let task_id = task.id.clone();
+            let retry_count = task.retry_count;
+            let retry_delay_sec = task.retry_delay_sec;
+
             if cancel.is_canceled() {
                 let _ = state.task_finished(&task_id, TaskStatus::Canceled, None);
                 return TaskResult::canceled();
@@ -1682,28 +1874,51 @@ impl TaskRunner for PlanTaskRunner {
             let mut task_ctx = ctx.clone();
             task_ctx.cwd = workdir.path().to_path_buf();
 
-            let result = 'result: {
-                let runner: &dyn Runner = if task.codex.is_some() {
-                    &codex
-                } else if task.claude_code.is_some() {
-                    &claude_code
-                } else {
-                    &opencode
-                };
+            let timeout_sec = task.timeout_sec.or(default_timeout_sec);
+            let mut attempt = 0u32;
+            let max_attempts = retry_count + 1; // Original attempt + retries
 
-                let child = match runner.spawn(task, &task_ctx) {
+            let result = loop {
+                attempt += 1;
+
+                if cancel.is_canceled() {
+                    let _ = state.task_finished(&task_id, TaskStatus::Canceled, None);
+                    break TaskResult::canceled();
+                }
+
+                if attempt > 1 {
+                    eprintln!(
+                        "task {task_id} retry attempt {}/{} after failure",
+                        attempt - 1,
+                        retry_count
+                    );
+                    if retry_delay_sec > 0 {
+                        tokio::time::sleep(Duration::from_secs(retry_delay_sec)).await;
+                    }
+                }
+
+                // Select runner and spawn child process
+                let child = if task.codex.is_some() {
+                    codex.spawn(task, &task_ctx)
+                } else if task.claude_code.is_some() {
+                    claude_code.spawn(task, &task_ctx)
+                } else {
+                    opencode.spawn(task, &task_ctx)
+                };
+                let child = match child {
                     Ok(child) => child,
                     Err(err) => {
                         eprintln!("task {task_id} spawn error: {err:#}");
-                        let _ = state.task_finished(&task_id, TaskStatus::Failed, Some(1));
-                        break 'result TaskResult::failed(1);
+                        if attempt >= max_attempts {
+                            let _ = state.task_finished(&task_id, TaskStatus::Failed, Some(1));
+                            break TaskResult::failed(1);
+                        }
+                        continue;
                     }
                 };
 
                 cancel.register(&task_id, child.clone());
                 let _ = state.task_started(&task_id, child.pid);
-
-                let timeout_sec = task.timeout_sec.or(default_timeout_sec);
 
                 let wait_future = tokio::task::spawn_blocking(move || child.wait());
                 let wait_result = if let Some(timeout_secs) = timeout_sec {
@@ -1729,8 +1944,13 @@ impl TaskRunner for PlanTaskRunner {
                                 }
                             }
                             cancel.unregister(&task_id);
-                            let _ = state.task_finished(&task_id, TaskStatus::Failed, Some(124));
-                            break 'result TaskResult::failed(124);
+
+                            if attempt >= max_attempts {
+                                let _ =
+                                    state.task_finished(&task_id, TaskStatus::Failed, Some(124));
+                                break TaskResult::failed(124);
+                            }
+                            continue;
                         }
                     }
                 } else {
@@ -1743,19 +1963,35 @@ impl TaskRunner for PlanTaskRunner {
                     Ok(Ok(status)) => status,
                     Ok(Err(err)) => {
                         eprintln!("task {task_id} wait error: {err}");
-                        let _ = state.task_finished(&task_id, TaskStatus::Failed, Some(1));
-                        break 'result TaskResult::failed(1);
+                        if attempt >= max_attempts {
+                            let _ = state.task_finished(&task_id, TaskStatus::Failed, Some(1));
+                            break TaskResult::failed(1);
+                        }
+                        continue;
                     }
                     Err(err) => {
                         eprintln!("task {task_id} join error: {err}");
-                        let _ = state.task_finished(&task_id, TaskStatus::Failed, Some(1));
-                        break 'result TaskResult::failed(1);
+                        if attempt >= max_attempts {
+                            let _ = state.task_finished(&task_id, TaskStatus::Failed, Some(1));
+                            break TaskResult::failed(1);
+                        }
+                        continue;
                     }
                 };
 
                 let result = map_exit_status(status, cancel.is_canceled());
+
+                // If failed but have retries remaining, continue
+                if result.status == TaskStatus::Failed && attempt < max_attempts {
+                    eprintln!(
+                        "task {task_id} failed with exit code {:?}, will retry",
+                        result.exit_code
+                    );
+                    continue;
+                }
+
                 let _ = state.task_finished(&task_id, result.status, result.exit_code);
-                break 'result result;
+                break result;
             };
 
             if let Some(manager) = &ctx.worktree_manager {

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -4,9 +4,10 @@ use std::path::PathBuf;
 use anyhow::{bail, Context, Result};
 use petgraph::algo::is_cyclic_directed;
 use petgraph::graphmap::DiGraphMap;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum TaskMode {
     Research,
@@ -14,7 +15,7 @@ pub enum TaskMode {
     Verify,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, JsonSchema)]
 pub struct WorktreeRunConfig {
     #[serde(default)]
     pub enabled: bool,
@@ -24,7 +25,7 @@ pub struct WorktreeRunConfig {
     pub shallow_depth: Option<u32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, JsonSchema)]
 pub struct RunConfig {
     #[serde(default)]
     pub name: Option<String>,
@@ -42,7 +43,7 @@ pub struct RunConfig {
     pub default_timeout_sec: Option<u64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct Plan {
     pub version: u32,
     #[serde(default)]
@@ -50,18 +51,20 @@ pub struct Plan {
     pub tasks: Vec<Task>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct CodexConfig {
     pub prompt: String,
     #[serde(default)]
     pub output_last_message: Option<PathBuf>,
     #[serde(default = "default_verify_after")]
+    #[schemars(default = "default_verify_after")]
     pub verify_after: bool,
     #[serde(default)]
     pub sandbox: Option<String>,
     #[serde(default)]
     pub ask_for_approval: Option<String>,
     #[serde(default = "default_json")]
+    #[schemars(default = "default_json")]
     pub json: bool,
 }
 
@@ -73,25 +76,27 @@ fn default_verify_after() -> bool {
     true
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ClaudeCodeConfig {
     pub prompt: String,
     #[serde(default)]
     pub model: Option<String>,
     #[serde(default = "default_json")]
+    #[schemars(default = "default_json")]
     pub json: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct OpencodeConfig {
     pub prompt: String,
     #[serde(default)]
     pub model: Option<String>,
     #[serde(default = "default_json")]
+    #[schemars(default = "default_json")]
     pub json: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct Task {
     pub id: String,
     #[serde(default)]
@@ -113,6 +118,12 @@ pub struct Task {
     pub claude_code: Option<ClaudeCodeConfig>,
     #[serde(default)]
     pub opencode: Option<OpencodeConfig>,
+    /// Number of retry attempts on failure (0 = no retry)
+    #[serde(default)]
+    pub retry_count: u32,
+    /// Delay in seconds between retry attempts
+    #[serde(default)]
+    pub retry_delay_sec: u64,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -237,4 +248,9 @@ impl Plan {
 
         Ok(())
     }
+}
+
+/// Generate JSON Schema for Plan
+pub fn plan_json_schema() -> schemars::schema::RootSchema {
+    schemars::schema_for!(Plan)
 }

--- a/tests/plan_validation_tests.rs
+++ b/tests/plan_validation_tests.rs
@@ -20,6 +20,8 @@ fn codex_task(id: &str, deps: Vec<&str>) -> Task {
         }),
         claude_code: None,
         opencode: None,
+        retry_count: 0,
+        retry_delay_sec: 0,
     }
 }
 
@@ -41,6 +43,8 @@ fn opencode_task(id: &str, deps: Vec<&str>) -> Task {
             model: None,
             json: true,
         }),
+        retry_count: 0,
+        retry_delay_sec: 0,
     }
 }
 
@@ -100,6 +104,8 @@ fn plan_rejects_empty_codex_prompt() {
         }),
         claude_code: None,
         opencode: None,
+        retry_count: 0,
+        retry_delay_sec: 0,
     };
 
     let plan = plan_with_tasks(vec![task]);
@@ -124,6 +130,8 @@ fn plan_rejects_empty_claude_code_prompt() {
             json: true,
         }),
         opencode: None,
+        retry_count: 0,
+        retry_delay_sec: 0,
     };
 
     let plan = plan_with_tasks(vec![task]);
@@ -155,6 +163,8 @@ fn plan_rejects_multiple_runner_configs() {
             json: true,
         }),
         opencode: None,
+        retry_count: 0,
+        retry_delay_sec: 0,
     };
 
     let plan = plan_with_tasks(vec![task]);
@@ -179,6 +189,8 @@ fn plan_accepts_valid_claude_code_task() {
             json: true,
         }),
         opencode: None,
+        retry_count: 0,
+        retry_delay_sec: 0,
     };
 
     let plan = plan_with_tasks(vec![task]);
@@ -206,6 +218,8 @@ fn plan_rejects_kind_mismatch_claude_code() {
         }),
         claude_code: None,
         opencode: None,
+        retry_count: 0,
+        retry_delay_sec: 0,
     };
 
     let plan = plan_with_tasks(vec![task]);
@@ -230,6 +244,8 @@ fn plan_rejects_empty_opencode_prompt() {
             model: None,
             json: true,
         }),
+        retry_count: 0,
+        retry_delay_sec: 0,
     };
 
     let plan = plan_with_tasks(vec![task]);
@@ -254,6 +270,8 @@ fn plan_accepts_valid_opencode_task() {
             model: Some("anthropic/claude-sonnet".to_string()),
             json: true,
         }),
+        retry_count: 0,
+        retry_delay_sec: 0,
     };
 
     let plan = plan_with_tasks(vec![task]);
@@ -281,6 +299,8 @@ fn plan_rejects_kind_mismatch_opencode() {
         }),
         claude_code: None,
         opencode: None,
+        retry_count: 0,
+        retry_delay_sec: 0,
     };
 
     let plan = plan_with_tasks(vec![task]);
@@ -309,6 +329,8 @@ fn plan_rejects_multiple_runner_configs_with_opencode() {
             model: None,
             json: true,
         }),
+        retry_count: 0,
+        retry_delay_sec: 0,
     };
 
     let plan = plan_with_tasks(vec![task]);


### PR DESCRIPTION
## 概要

quedexのユーザー体験、信頼性、運用性を向上させる6つの新機能を追加します。

## 変更内容

### Phase 1: 独立した小機能
| 機能 | 説明 |
|------|------|
| `quedex init` | plan.jsonテンプレートを生成（新規ユーザー向け） |
| `--dry-run` | 実行計画を表示（タスクは実行しない） |
| `--verbose` | デバッグ用詳細ログ出力 |
| `quedex history` | 過去の実行履歴一覧表示 |

### Phase 2: 中規模機能
| 機能 | 説明 |
|------|------|
| 自動リトライ | Taskに`retry_count`, `retry_delay_sec`フィールド追加 |
| JSON Schema | `quedex schema`コマンドでスキーマ出力（VSCode補完対応） |

## 使用例

```bash
# テンプレート生成
quedex init
quedex init -o myplan.json

# ドライラン
quedex run plan.json --dry-run

# 詳細ログ
quedex --verbose run plan.json

# 履歴表示
quedex history
quedex history --limit 20 --json

# スキーマ出力
quedex schema > schema.json
```

### リトライ設定例（plan.json）
```json
{
  "tasks": [{
    "id": "flaky-task",
    "mode": "implement",
    "retry_count": 3,
    "retry_delay_sec": 10,
    "codex": { "prompt": "..." }
  }]
}
```

## 後方互換性

- 新フィールド（`retry_count`, `retry_delay_sec`）は`#[serde(default)]`で既存planと互換
- 新コマンド/オプションは既存の動作に影響しない

## テスト方法

- [x] `cargo test` - 既存テストすべてパス
- [x] `cargo clippy` - 警告なし
- [x] 各コマンドの手動動作確認