### PR TITLE
fix: miseでインストールされたツールが認識されない問題を修正

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -826,9 +826,15 @@ async fn handle_run(
             None
         }
     });
+
+    // Merge system environment variables with plan.run.env
+    // plan.run.env takes precedence over system env vars
+    let mut env: HashMap<String, String> = std::env::vars().collect();
+    env.extend(plan.run.env.clone());
+
     let ctx = RunContext {
         cwd,
-        env: plan.run.env.clone(),
+        env,
         store: store.clone(),
         worktree_manager,
         variables: plan.variables.clone(),
@@ -1372,9 +1378,15 @@ async fn handle_retry(
             None
         }
     });
+
+    // Merge system environment variables with plan.run.env
+    // plan.run.env takes precedence over system env vars
+    let mut env: HashMap<String, String> = std::env::vars().collect();
+    env.extend(plan.run.env.clone());
+
     let ctx = RunContext {
         cwd,
-        env: plan.run.env.clone(),
+        env,
         store: store.clone(),
         worktree_manager,
         variables: plan.variables.clone(),

--- a/src/runner/claude_code.rs
+++ b/src/runner/claude_code.rs
@@ -64,7 +64,6 @@ impl Runner for ClaudeCodeRunner {
         let child = cmd
             .current_dir(&ctx.cwd)
             .envs(&ctx.env)
-            .env("PATH", std::env::var("PATH").unwrap_or_default())
             .stdout(Stdio::from(stdout))
             .stderr(Stdio::from(stderr))
             .spawn()

--- a/src/runner/codex.rs
+++ b/src/runner/codex.rs
@@ -76,7 +76,6 @@ impl Runner for CodexRunner {
         let child = cmd
             .current_dir(&ctx.cwd)
             .envs(&ctx.env)
-            .env("PATH", std::env::var("PATH").unwrap_or_default())
             .stdout(Stdio::from(stdout))
             .stderr(Stdio::from(stderr))
             .spawn()

--- a/src/runner/opencode.rs
+++ b/src/runner/opencode.rs
@@ -63,7 +63,6 @@ impl Runner for OpencodeRunner {
         let child = cmd
             .current_dir(&ctx.cwd)
             .envs(&ctx.env)
-            .env("PATH", std::env::var("PATH").unwrap_or_default())
             .stdout(Stdio::from(stdout))
             .stderr(Stdio::from(stderr))
             .spawn()


### PR DESCRIPTION
## 概要

miseでインストールされたcodex等のツールがquedexから認識されない問題を修正。

## 問題

- `which codex` → `/Users/t3ta/.local/bin/codex`
- `mise which codex` → `/Users/t3ta/.local/share/mise/installs/node/23.8.0/bin/codex`

`RunContext.env`にシステム環境変数が含まれておらず、`plan.run.env`のみが設定されていたため、miseが設定するPATHや環境変数が子プロセスに引き継がれなかった。

## 変更内容

- `src/main.rs`: `handle_run`と`handle_retry`で`RunContext.env`の構築方法を修正
  - `std::env::vars()`でシステム環境変数を取得
  - `plan.run.env`で上書き（plan.run.envが優先）
- `src/runner/codex.rs`: 冗長なPATH復旧コードを削除
- `src/runner/claude_code.rs`: 冗長なPATH復旧コードを削除
- `src/runner/opencode.rs`: 冗長なPATH復旧コードを削除

## テスト方法

- `cargo build` - ビルド確認済み
- `cargo test` - 全テストパス済み（32 + 46テスト）
- miseでインストールされたcodexを使用するplan.jsonを実行して動作確認