### PR TITLE
feat: Add system_prompt for shared context across all tasks

### DIFF
--- a/.claude/skills/quedex/SKILL.md
+++ b/.claude/skills/quedex/SKILL.md
@@ -134,6 +134,37 @@ quedex retry <run_id> --group <name>       # Retry group
 | `output_files` | 特定ファイルをキャプチャしたい場合 |
 | `auto_commit` | テストで無効化したい場合（デフォルトtrue） |
 | `squash` | 最終統合タスクで全コミットを1つにまとめたい場合 |
+| `system_prompt` | 全タスクに共通のコンテキストを渡したい場合 |
+
+### system_prompt（共通プロンプト）
+
+全タスクのプロンプトの前に追加される共通コンテキスト。プロジェクト全体（quedex.toml）またはプラン単位で定義可能。
+
+**quedex.toml（プロジェクト全体）:**
+```toml
+system_prompt = """
+このプロジェクトは Rust で書かれています。
+コーディング規約:
+- snake_case を使用
+- エラー処理には anyhow を使用
+"""
+```
+
+**プランファイル（プラン単位で上書き）:**
+```yaml
+version: 1
+run:
+  system_prompt: |
+    このタスク群は認証機能の実装です。
+    既存の auth モジュールとの整合性を保ってください。
+tasks:
+  - id: task-1
+    mode: implement
+    codex:
+      prompt: "ログイン機能を実装して"
+```
+
+プラン単位の `system_prompt` が設定されている場合、quedex.toml の設定を上書きします。
 
 ## TUI Key Bindings
 

--- a/.claude/skills/quedex/references/schema.md
+++ b/.claude/skills/quedex/references/schema.md
@@ -18,6 +18,7 @@
 | `title` | なし | 必要な場合のみ |
 | `variables` | なし | 3箇所以上で同じ値を使う場合のみ |
 | `groups` | なし | バッチ操作が必要な場合のみ |
+| `system_prompt` | なし | 全タスクに共通コンテキストを渡す場合のみ |
 
 ---
 
@@ -98,7 +99,8 @@ Array of Task objects. Must contain at least one task.
   "fail_fast": true,
   "default_timeout_sec": 3600,
   "worktree": { "enabled": true },
-  "notifications": { "url": "https://hooks.slack.com/..." }
+  "notifications": { "url": "https://hooks.slack.com/..." },
+  "system_prompt": "全タスク共通のコンテキスト"
 }
 ```
 
@@ -152,6 +154,21 @@ Array of Task objects. Must contain at least one task.
   - `url`: Webhook URL (Slack/Discord compatible)
   - `events`: Array of events (`"on_start"`, `"on_task_complete"`, `"on_complete"`, `"on_failure"`)
   - `username`: Custom username for notifications
+
+### system_prompt (optional)
+
+- **Type**: `string`
+- **Purpose**: 全タスクのプロンプトの前に追加される共通コンテキスト
+- **Priority**: プラン単位の設定が `quedex.toml` の設定を上書き
+- **Example**:
+```yaml
+run:
+  system_prompt: |
+    このプロジェクトは Rust で書かれています。
+    コーディング規約:
+    - snake_case を使用
+    - エラー処理には anyhow を使用
+```
 
 ---
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,8 @@ pub struct Config {
     pub store: Option<PathBuf>,
     /// Default timeout for tasks in seconds
     pub default_timeout_sec: Option<u64>,
+    /// System prompt to prepend to all task prompts
+    pub system_prompt: Option<String>,
 }
 
 impl Config {
@@ -108,6 +110,7 @@ mod tests {
         assert!(config.fail_fast.is_none());
         assert!(config.store.is_none());
         assert!(config.default_timeout_sec.is_none());
+        assert!(config.system_prompt.is_none());
     }
 
     #[test]
@@ -117,12 +120,14 @@ max_concurrency = 4
 fail_fast = false
 store = "/tmp/quedex"
 default_timeout_sec = 300
+system_prompt = "You are a helpful assistant."
 "#;
         let config: Config = toml::from_str(toml).unwrap();
         assert_eq!(config.max_concurrency, Some(4));
         assert_eq!(config.fail_fast, Some(false));
         assert_eq!(config.store, Some(PathBuf::from("/tmp/quedex")));
         assert_eq!(config.default_timeout_sec, Some(300));
+        assert_eq!(config.system_prompt, Some("You are a helpful assistant.".to_string()));
     }
 
     #[test]
@@ -144,6 +149,7 @@ max_concurrency = 2
             fail_fast: Some(false),
             store: Some(PathBuf::from("/config/store")),
             default_timeout_sec: Some(300),
+            system_prompt: None,
         };
 
         // CLI values should override config
@@ -169,6 +175,7 @@ max_concurrency = 2
             fail_fast: Some(false),
             store: Some(PathBuf::from("/config/store")),
             default_timeout_sec: Some(300),
+            system_prompt: None,
         };
 
         // No CLI values, should use config
@@ -187,11 +194,29 @@ max_concurrency = 2
             fail_fast: Some(true),
             store: None,
             default_timeout_sec: None,
+            system_prompt: None,
         };
 
         // --no-fail-fast should override config
         let effective = EffectiveOptions::new(None, None, true, true, &config);
 
         assert!(!effective.fail_fast);
+    }
+
+    #[test]
+    fn test_parse_multiline_system_prompt() {
+        let toml = r#"
+system_prompt = """
+This project is written in Rust.
+Coding conventions:
+- Use snake_case
+- Use anyhow for error handling
+"""
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert!(config.system_prompt.is_some());
+        let prompt = config.system_prompt.unwrap();
+        assert!(prompt.contains("Rust"));
+        assert!(prompt.contains("snake_case"));
     }
 }

--- a/src/dry_run.rs
+++ b/src/dry_run.rs
@@ -243,6 +243,7 @@ mod tests {
                 fail_fast: None,
                 default_timeout_sec: None,
                 notifications: None,
+                system_prompt: None,
             },
             groups: std::collections::HashMap::new(),
             tasks,

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,7 @@ async fn dispatch(cli: Cli) -> Result<i32> {
             if dry_run {
                 handle_dry_run(&cli.global, &plan)
             } else {
-                handle_run(&cli.global, &effective, &plan, recovery, run_id, base_dir).await
+                handle_run(&cli.global, &effective, &config, &plan, recovery, run_id, base_dir).await
             }
         }
         Commands::Start {
@@ -110,7 +110,7 @@ async fn dispatch(cli: Cli) -> Result<i32> {
             task_id,
             group,
             reload_plan,
-        } => handle_retry(&cli.global, &effective, &run_id, task_id, group, reload_plan).await,
+        } => handle_retry(&cli.global, &effective, &config, &run_id, task_id, group, reload_plan).await,
         Commands::Cancel { run_id, task_id, group } => handle_cancel(&effective, &run_id, task_id, group),
         Commands::Clean {
             run_id,
@@ -733,6 +733,7 @@ fn handle_stats(
 async fn handle_run(
     _global: &GlobalOptions,
     effective: &EffectiveOptions,
+    config: &Config,
     plan_arg: &str,
     recovery: RecoveryOptions,
     run_id: Option<String>,
@@ -834,11 +835,19 @@ async fn handle_run(
     let mut env: HashMap<String, String> = std::env::vars().collect();
     env.extend(plan.run.env.clone());
 
+    // Resolve system_prompt: plan-level overrides config-level
+    let system_prompt = plan
+        .run
+        .system_prompt
+        .clone()
+        .or_else(|| config.system_prompt.clone());
+
     let ctx = RunContext {
         cwd,
         env,
         store: store.clone(),
         worktree_manager,
+        system_prompt,
     };
 
     let (mut state, initial_states) = if recovery.resume {
@@ -1432,6 +1441,7 @@ fn collect_downstream_tasks(plan: &Plan, target_ids: &HashSet<String>) -> HashSe
 async fn handle_retry(
     _global: &GlobalOptions,
     effective: &EffectiveOptions,
+    config: &Config,
     run_id: &str,
     task_id: Option<String>,
     group: Option<String>,
@@ -1651,11 +1661,19 @@ async fn handle_retry(
     let mut env: HashMap<String, String> = std::env::vars().collect();
     env.extend(plan.run.env.clone());
 
+    // Resolve system_prompt: plan-level overrides config-level
+    let system_prompt = plan
+        .run
+        .system_prompt
+        .clone()
+        .or_else(|| config.system_prompt.clone());
+
     let ctx = RunContext {
         cwd,
         env,
         store: store.clone(),
         worktree_manager,
+        system_prompt,
     };
 
     let state_handle = StateHandle::new(store.clone(), state);

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -58,6 +58,9 @@ pub struct RunConfig {
     /// Webhook notification configuration
     #[serde(default)]
     pub notifications: Option<NotificationConfig>,
+    /// System prompt to prepend to all task prompts (overrides quedex.toml)
+    #[serde(default)]
+    pub system_prompt: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/src/runner/claude_code.rs
+++ b/src/runner/claude_code.rs
@@ -28,7 +28,13 @@ impl Runner for ClaudeCodeRunner {
             .as_ref()
             .context("claude_code config missing")?;
 
-        let prompt = config.prompt.clone();
+        // Build prompt with optional system prompt prefix
+        let mut prompt = String::new();
+        if let Some(ref sys) = ctx.system_prompt {
+            prompt.push_str(sys);
+            prompt.push_str("\n\n");
+        }
+        prompt.push_str(&config.prompt);
 
         let stdout_path = ctx.store.log_path(&task.id, LogStream::Stdout);
         let stderr_path = ctx.store.log_path(&task.id, LogStream::Stderr);

--- a/src/runner/codex.rs
+++ b/src/runner/codex.rs
@@ -30,7 +30,13 @@ impl Runner for CodexRunner {
             .as_ref()
             .context("codex config missing")?;
 
-        let mut prompt = config.prompt.clone();
+        // Build prompt with optional system prompt prefix
+        let mut prompt = String::new();
+        if let Some(ref sys) = ctx.system_prompt {
+            prompt.push_str(sys);
+            prompt.push_str("\n\n");
+        }
+        prompt.push_str(&config.prompt);
         if matches!(task.mode, TaskMode::Implement) && config.verify_after {
             prompt.push_str("\n\n");
             prompt.push_str(VERIFY_AFTER_SUFFIX);

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -22,6 +22,8 @@ pub struct RunContext {
     pub env: HashMap<String, String>,
     pub store: Arc<dyn Store>,
     pub worktree_manager: Option<Arc<WorktreeManager>>,
+    /// System prompt to prepend to all task prompts
+    pub system_prompt: Option<String>,
 }
 
 impl Clone for RunContext {
@@ -31,6 +33,7 @@ impl Clone for RunContext {
             env: self.env.clone(),
             store: Arc::clone(&self.store),
             worktree_manager: self.worktree_manager.clone(),
+            system_prompt: self.system_prompt.clone(),
         }
     }
 }

--- a/src/runner/opencode.rs
+++ b/src/runner/opencode.rs
@@ -28,7 +28,13 @@ impl Runner for OpencodeRunner {
             .as_ref()
             .context("opencode config missing")?;
 
-        let prompt = config.prompt.clone();
+        // Build prompt with optional system prompt prefix
+        let mut prompt = String::new();
+        if let Some(ref sys) = ctx.system_prompt {
+            prompt.push_str(sys);
+            prompt.push_str("\n\n");
+        }
+        prompt.push_str(&config.prompt);
 
         let stdout_path = ctx.store.log_path(&task.id, LogStream::Stdout);
         let stderr_path = ctx.store.log_path(&task.id, LogStream::Stderr);

--- a/tests/dry_run_tests.rs
+++ b/tests/dry_run_tests.rs
@@ -16,6 +16,7 @@ fn create_test_plan(tasks: Vec<Task>) -> Plan {
             fail_fast: None,
             default_timeout_sec: None,
             notifications: None,
+            system_prompt: None,
         },
         groups: HashMap::new(),
         tasks,

--- a/tests/plan_validation_tests.rs
+++ b/tests/plan_validation_tests.rs
@@ -429,3 +429,48 @@ fn plan_rejects_parent_dir_in_output_files() {
     let plan = plan_with_tasks(vec![task]);
     assert_validation_error(plan, "contains '..'");
 }
+
+#[test]
+fn plan_accepts_system_prompt_in_run_config() {
+    use quedex::plan::PlanFormat;
+
+    let yaml = r#"
+version: 1
+run:
+  system_prompt: |
+    This is a test project.
+    Please follow coding conventions.
+tasks:
+  - id: test
+    mode: implement
+    codex:
+      prompt: "implement feature"
+"#;
+    let plan = Plan::parse_str(yaml, PlanFormat::Yaml).unwrap();
+    assert!(plan.validate().is_ok());
+    assert!(plan.run.system_prompt.is_some());
+    let sys_prompt = plan.run.system_prompt.unwrap();
+    assert!(sys_prompt.contains("test project"));
+    assert!(sys_prompt.contains("coding conventions"));
+}
+
+#[test]
+fn plan_accepts_empty_run_config_system_prompt() {
+    use quedex::plan::PlanFormat;
+
+    let json = r#"{
+        "version": 1,
+        "tasks": [
+            {
+                "id": "test",
+                "mode": "implement",
+                "codex": {
+                    "prompt": "implement feature"
+                }
+            }
+        ]
+    }"#;
+    let plan = Plan::parse_str(json, PlanFormat::Json).unwrap();
+    assert!(plan.validate().is_ok());
+    assert!(plan.run.system_prompt.is_none());
+}


### PR DESCRIPTION
## Summary

- Add `system_prompt` field to `quedex.toml` (project-wide) and `run.system_prompt` in plan files (per-plan)
- The system prompt is prepended to all task prompts
- Plan-level setting overrides project-level setting

## Use Cases

- Provide consistent coding conventions to all tasks
- Share project-specific guidelines across tasks
- Add common context without repeating in every task prompt

## Example

**quedex.toml (project-wide):**
```toml
system_prompt = """
このプロジェクトは Rust で書かれています。
コーディング規約:
- snake_case を使用
- エラー処理には anyhow を使用
"""
```

**Plan file (per-plan override):**
```yaml
version: 1
run:
  system_prompt: |
    このタスク群は認証機能の実装です。
    既存の auth モジュールとの整合性を保ってください。
tasks:
  - id: task-1
    mode: implement
    codex:
      prompt: "ログイン機能を実装して"
```

## Changes

- `src/config.rs`: Add `system_prompt` field to Config
- `src/plan.rs`: Add `system_prompt` field to RunConfig
- `src/runner/*.rs`: Prepend system_prompt to task prompts
- `src/main.rs`: Resolve system_prompt (plan > config)
- Tests and documentation updated

## Test plan

- [x] All existing tests pass
- [x] New tests for system_prompt parsing added
- [x] cargo clippy passes