### PR TITLE
run.env の環境変数展開で PATH を継承

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -745,7 +745,7 @@ fn expand_env_placeholders(value: &str, base_env: &HashMap<String, String>) -> S
                 chars.next();
                 let mut token = String::new();
                 let mut closed = false;
-                while let Some(c) = chars.next() {
+                for c in chars.by_ref() {
                     if c == '}' {
                         closed = true;
                         break;


### PR DESCRIPTION
## Summary
- run.env に $VAR/${VAR}/${env.VAR} の展開を追加し、spawn したプロセスで PATH を継承できるようにしました
- 展開済みの環境変数をタスク実行と条件評価で共有するよう統一しました

## Testing
- cargo build