### PR TITLE
fix: Fix layout in TUI run selection UI

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2410,7 +2410,8 @@ fn truncate_str(s: &str, max_len: usize) -> String {
     } else if max_len <= 3 {
         ".".repeat(max_len)
     } else {
-        format!("{}...", &s[..max_len - 3])
+        let truncated: String = s.chars().take(max_len - 3).collect();
+        format!("{}...", truncated)
     }
 }
 


### PR DESCRIPTION
## 概要

複数のrunがある場合のTUI選択画面で、列がずれる問題を修正しました。

## 変更内容

### `print_run_selection_ui`関数の修正
- 可変長フォーマットから固定幅フォーマットに変更
- 各列の幅を固定:
  - status: 10文字
  - short_id: 8文字  
  - run_name: 25文字（超えたら`...`で省略）
  - reason: 20文字（超えたら`...`で省略）

### 新規追加
- `truncate_str`ヘルパー関数: 長すぎる文字列を指定長で切り詰める

## 修正前/修正後

### 修正前
```
Running:
> [Running] a1b2c3d4 my-task-name (task-1: codex run)
  [Completed] e5f6g7h8 another-task-name (idle)
```
※ `status`の文字数差で列がずれる

### 修正後
```
Running:
> [Running   ] a1b2c3d4 my-task-name          (task-1: codex run)
  [Completed ] e5f6g7h8 another-task-name     (idle)
```
※ 各列が固定幅で整列

## 動作確認

```bash
cargo build  # 成功
cargo clippy -- -D warnings  # 成功
```