### PR TITLE
Remove start command, use run only

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,8 @@ tasks:
 ### 3. 実行
 
 ```bash
-# 前面実行
+# 実行（バックグラウンド実行も兼ねる）
 quedex run plan.yaml
-
-# バックグラウンド実行
-quedex start plan.yaml
 # → run_id: abc123...
 
 # TUI で監視
@@ -96,7 +93,7 @@ cargo run -- run plan.yaml
 ### 基本コマンド
 
 - **`quedex init [-o <path>] [--force]`**: plan テンプレートを生成（JSON/YAML）
-- **`quedex run <plan.json|->` / `quedex start <plan.json|->`**: plan を実行
+- **`quedex run <plan.json|->`**: plan を実行
   - `--resume`: 途中から再開（Running タスクのプロセス状態を確認）
   - `--clean-start`: 状態をクリアして最初から実行
   - `--dry-run`: 実行せずに計画を表示
@@ -526,8 +523,8 @@ tasks:
 #### 実行コマンド例
 
 ```bash
-# planを実行（バックグラウンド）
-quedex start examples/hybrid-workflow-sample.yaml
+# planを実行
+quedex run examples/hybrid-workflow-sample.yaml
 # → run_id: abc123...
 
 # TUIで監視（draft-auth と draft-api が並列実行される様子が確認できる）
@@ -682,7 +679,7 @@ quedex outputs abc123 --task generate-report
 
 ```bash
 # planを実行
-quedex start plan.yaml
+quedex run plan.yaml
 # → run_id: abc123...
 
 # TUIで監視
@@ -774,7 +771,7 @@ tasks:
 
 ```bash
 # 実行
-quedex start plan.yaml
+quedex run plan.yaml
 
 # 結果:
 # - implement-api 完了 → commit: "feat: APIの実装 [implement-api]"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -51,14 +51,6 @@ pub enum Commands {
         #[arg(long, action = ArgAction::SetTrue)]
         dry_run: bool,
     },
-    /// Start a plan in background
-    Start {
-        plan: String,
-        #[command(flatten)]
-        recovery: RecoveryOptions,
-        #[arg(long, hide = true)]
-        run_id: Option<String>,
-    },
     /// Show run status
     Status {
         run_id: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,11 +94,6 @@ async fn dispatch(cli: Cli) -> Result<i32> {
                 handle_run(&cli.global, &effective, &config, &plan, recovery, run_id, base_dir).await
             }
         }
-        Commands::Start {
-            plan,
-            recovery,
-            run_id,
-        } => handle_start(&cli.global, &effective, &plan, recovery, run_id).await,
         Commands::Status { run_id, group, json } => handle_status(&effective, run_id, group, json),
         Commands::Tui { run_id } => handle_tui(&effective, run_id),
         Commands::Logs {
@@ -1121,113 +1116,6 @@ async fn handle_run(
     }
 
     Ok(exit_code)
-}
-
-async fn handle_start(
-    _global: &GlobalOptions,
-    effective: &EffectiveOptions,
-    plan_arg: &str,
-    recovery: RecoveryOptions,
-    run_id: Option<String>,
-) -> Result<i32> {
-    if recovery.resume && run_id.is_none() {
-        return Err(anyhow!("--resume requires --run-id"));
-    }
-    let (mut plan, base_dir) = load_plan(plan_arg)?;
-
-    let store_root = resolve_store_path(effective.store.as_ref())?;
-    let run_id = run_id.unwrap_or_else(|| Uuid::new_v4().to_string());
-    let snapshot_path = plan_snapshot_path(&store_root, &run_id);
-
-    if recovery.resume {
-        if !snapshot_path.exists() {
-            return Err(anyhow!("run {run_id} has no plan snapshot to resume"));
-        }
-        plan = load_plan_snapshot(&store_root, &run_id)?;
-        let store = FsStore::new(&store_root, &run_id)?;
-        let report = recover_running_tasks(&store)?;
-        if !report.alive_tasks.is_empty() {
-            return Err(anyhow!(
-                "run {} still has running tasks: {}",
-                run_id,
-                report.alive_tasks.join(", ")
-            ));
-        }
-    }
-
-    if let Err(err) = plan.validate() {
-        eprintln!("plan validation error: {err}");
-        return Ok(3);
-    }
-    #[allow(clippy::collapsible_if)]
-    if plan
-        .tasks
-        .iter()
-        .any(|task| matches!(task.kind.as_deref(), Some("codex")) || task.codex.is_some())
-    {
-        if let Err(err) = check_codex_available() {
-            eprintln!("environment error: {err}");
-            return Ok(4);
-        }
-    }
-    #[allow(clippy::collapsible_if)]
-    if plan.tasks.iter().any(|task| {
-        matches!(task.kind.as_deref(), Some("claude_code")) || task.claude_code.is_some()
-    }) {
-        if let Err(err) = check_claude_code_available() {
-            eprintln!("environment error: {err}");
-            return Ok(4);
-        }
-    }
-
-    #[allow(clippy::collapsible_if)]
-    if plan
-        .tasks
-        .iter()
-        .any(|task| matches!(task.kind.as_deref(), Some("opencode")) || task.opencode.is_some())
-    {
-        if let Err(err) = check_opencode_available() {
-            eprintln!("environment error: {err}");
-            return Ok(4);
-        }
-    }
-
-    let plan_path = if recovery.resume {
-        snapshot_path
-    } else {
-        write_plan_snapshot(&store_root, &run_id, &plan)?
-    };
-
-    let exe = env::current_exe().context("resolve current executable")?;
-    let mut cmd = std::process::Command::new(exe);
-    cmd.arg("run")
-        .arg(plan_path)
-        .arg("--run-id")
-        .arg(&run_id)
-        .arg("--base-dir")
-        .arg(&base_dir);
-    if recovery.resume {
-        cmd.arg("--resume");
-    }
-    if recovery.clean_start {
-        cmd.arg("--clean-start");
-    }
-    if let Some(store_path) = effective.store.as_ref() {
-        cmd.arg("--store").arg(store_path);
-    }
-    if let Some(max) = effective.max_concurrency {
-        cmd.arg("--max-concurrency").arg(max.to_string());
-    }
-    if !effective.fail_fast {
-        cmd.arg("--no-fail-fast");
-    }
-    cmd.stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null());
-    cmd.spawn().context("spawn background run")?;
-
-    println!("{run_id}");
-    Ok(0)
 }
 
 fn handle_status(


### PR DESCRIPTION
## Summary
- `quedex start` コマンドを廃止し、`quedex run` のみに統一しました
- CLI のシンプル化と使い方の明確化を目的としています

## Changes
- `src/cli.rs`: `Commands::Start` variant を削除（8行削除）
- `src/main.rs`: `handle_start` 関数とそのマッチアームを削除（112行削除）
- `README.md`: start コマンドの記述を5箇所削除/更新（15行変更）

## Verification
- ✅ cargo build: 成功
- ✅ cargo test: 81 tests passed
- ✅ cargo clippy: 成功