### PR TITLE
feat: completion gate の出力をストリーミング化

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4152,8 +4152,9 @@ async fn run_completion_gate(
     store: &Arc<dyn Store>,
     env: &HashMap<String, String>,
 ) -> Option<i32> {
-    // Open log files and write header before spawning so output streams
-    // directly to disk instead of being buffered in memory.
+    use tokio::io::AsyncReadExt;
+
+    // Open log files and write header before spawning.
     let mut stdout_file = match store.open_log(task_id, LogStream::Stdout) {
         Ok(f) => f,
         Err(_) => return None,
@@ -4166,14 +4167,17 @@ async fn run_completion_gate(
     };
     let _ = writeln!(stderr_file, "\n[completion gate:{}]", gate.name);
 
+    // Use piped stdout/stderr so we wait for pipe EOF from all fd holders
+    // (including backgrounded children), while streaming output to log files
+    // incrementally to avoid buffering everything in memory.
     let mut command = tokio::process::Command::new("sh");
     command
         .arg("-c")
         .arg(&gate.command)
         .current_dir(cwd)
         .envs(env)
-        .stdout(Stdio::from(stdout_file))
-        .stderr(Stdio::from(stderr_file))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .kill_on_drop(true);
     let mut child = match command.spawn() {
         Ok(child) => child,
@@ -4189,7 +4193,50 @@ async fn run_completion_gate(
         }
     };
 
-    match tokio::time::timeout(Duration::from_secs(gate.timeout_sec), child.wait()).await {
+    let child_stdout = child.stdout.take();
+    let child_stderr = child.stderr.take();
+
+    // Spawn tasks that stream pipe output to log files in 8 KiB chunks.
+    let stdout_task = tokio::spawn(async move {
+        if let Some(mut reader) = child_stdout {
+            let mut buf = [0u8; 8192];
+            loop {
+                match reader.read(&mut buf).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => {
+                        let _ = stdout_file.write_all(&buf[..n]);
+                    }
+                }
+            }
+        }
+    });
+    let stderr_task = tokio::spawn(async move {
+        if let Some(mut reader) = child_stderr {
+            let mut buf = [0u8; 8192];
+            loop {
+                match reader.read(&mut buf).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => {
+                        let _ = stderr_file.write_all(&buf[..n]);
+                    }
+                }
+            }
+        }
+    });
+
+    // Wait for child exit AND pipe EOF (covers backgrounded subprocesses
+    // that inherit the pipe fds).
+    let result = tokio::time::timeout(Duration::from_secs(gate.timeout_sec), async {
+        let status = child.wait().await;
+        // Pipes may still carry data from background children after the
+        // shell exits; wait for EOF on both streams.
+        let _ = stdout_task.await;
+        let _ = stderr_task.await;
+        status
+    })
+    .await;
+
+    match result {
         Ok(Ok(status)) => status.code(),
         Ok(Err(err)) => {
             if let Ok(mut stderr_log) = store.open_log(task_id, LogStream::Stderr) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4280,6 +4280,8 @@ async fn run_completion_gate(
         }
         Err(_) => {
             let _ = child.kill().await;
+            // Reap the child to avoid leaving a zombie on Unix.
+            let _ = child.wait().await;
             stdout_abort.abort();
             stderr_abort.abort();
             if let Ok(mut stderr_log) = store.open_log(task_id, LogStream::Stderr) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4251,6 +4251,18 @@ async fn run_completion_gate(
             {
                 stdout_abort.abort();
                 stderr_abort.abort();
+                // A descendant still holds pipe fds open after the
+                // timeout budget is exhausted — treat the gate as failed
+                // so it behaves the same as the old wait_with_output()
+                // path.
+                if let Ok(mut stderr_log) = store.open_log(task_id, LogStream::Stderr) {
+                    let _ = writeln!(
+                        stderr_log,
+                        "\n[completion gate:{}] timed out after {}s (pipe drain exceeded budget)",
+                        gate.name, gate.timeout_sec
+                    );
+                }
+                return None;
             }
             status.code()
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4230,15 +4230,28 @@ async fn run_completion_gate(
     let stdout_abort = stdout_task.abort_handle();
     let stderr_abort = stderr_task.abort_handle();
 
-    // Timeout applies only to the child process itself.  Pipe draining
-    // runs outside the timeout window so that slow disk I/O does not
-    // penalise a gate that exited in time.
-    match tokio::time::timeout(Duration::from_secs(gate.timeout_sec), child.wait()).await {
+    // Timeout applies to the child process; pipe draining gets the
+    // remaining budget so that (a) slow disk I/O during normal operation
+    // does not penalise a gate that exited in time, and (b) backgrounded
+    // processes that inherited pipe fds cannot hang the gate forever.
+    let deadline = Duration::from_secs(gate.timeout_sec);
+    let start = std::time::Instant::now();
+    match tokio::time::timeout(deadline, child.wait()).await {
         Ok(Ok(status)) => {
             // Child exited within budget.  Drain remaining pipe data
-            // outside the timeout so log-file writes are not penalised.
-            let _ = stdout_task.await;
-            let _ = stderr_task.await;
+            // using whatever time is left so bg fd holders cannot block
+            // indefinitely.
+            let remaining = deadline.saturating_sub(start.elapsed());
+            if tokio::time::timeout(remaining, async {
+                let _ = stdout_task.await;
+                let _ = stderr_task.await;
+            })
+            .await
+            .is_err()
+            {
+                stdout_abort.abort();
+                stderr_abort.abort();
+            }
             status.code()
         }
         Ok(Err(err)) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4224,21 +4224,26 @@ async fn run_completion_gate(
         }
     });
 
-    // Wait for child exit AND pipe EOF (covers backgrounded subprocesses
-    // that inherit the pipe fds).
-    let result = tokio::time::timeout(Duration::from_secs(gate.timeout_sec), async {
-        let status = child.wait().await;
-        // Pipes may still carry data from background children after the
-        // shell exits; wait for EOF on both streams.
-        let _ = stdout_task.await;
-        let _ = stderr_task.await;
-        status
-    })
-    .await;
+    // Grab abort handles so we can stop the drain tasks from outside the
+    // timeout future if needed (they are moved into the future on the
+    // success path but may outlive it on timeout).
+    let stdout_abort = stdout_task.abort_handle();
+    let stderr_abort = stderr_task.abort_handle();
 
-    match result {
-        Ok(Ok(status)) => status.code(),
+    // Timeout applies only to the child process itself.  Pipe draining
+    // runs outside the timeout window so that slow disk I/O does not
+    // penalise a gate that exited in time.
+    match tokio::time::timeout(Duration::from_secs(gate.timeout_sec), child.wait()).await {
+        Ok(Ok(status)) => {
+            // Child exited within budget.  Drain remaining pipe data
+            // outside the timeout so log-file writes are not penalised.
+            let _ = stdout_task.await;
+            let _ = stderr_task.await;
+            status.code()
+        }
         Ok(Err(err)) => {
+            stdout_abort.abort();
+            stderr_abort.abort();
             if let Ok(mut stderr_log) = store.open_log(task_id, LogStream::Stderr) {
                 let _ = writeln!(
                     stderr_log,
@@ -4250,6 +4255,8 @@ async fn run_completion_gate(
         }
         Err(_) => {
             let _ = child.kill().await;
+            stdout_abort.abort();
+            stderr_abort.abort();
             if let Ok(mut stderr_log) = store.open_log(task_id, LogStream::Stderr) {
                 let _ = writeln!(
                     stderr_log,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4152,16 +4152,30 @@ async fn run_completion_gate(
     store: &Arc<dyn Store>,
     env: &HashMap<String, String>,
 ) -> Option<i32> {
+    // Open log files and write header before spawning so output streams
+    // directly to disk instead of being buffered in memory.
+    let mut stdout_file = match store.open_log(task_id, LogStream::Stdout) {
+        Ok(f) => f,
+        Err(_) => return None,
+    };
+    let _ = writeln!(stdout_file, "\n[completion gate:{}]", gate.name);
+
+    let mut stderr_file = match store.open_log(task_id, LogStream::Stderr) {
+        Ok(f) => f,
+        Err(_) => return None,
+    };
+    let _ = writeln!(stderr_file, "\n[completion gate:{}]", gate.name);
+
     let mut command = tokio::process::Command::new("sh");
     command
         .arg("-c")
         .arg(&gate.command)
         .current_dir(cwd)
         .envs(env)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
+        .stdout(Stdio::from(stdout_file))
+        .stderr(Stdio::from(stderr_file))
         .kill_on_drop(true);
-    let child = match command.spawn() {
+    let mut child = match command.spawn() {
         Ok(child) => child,
         Err(err) => {
             if let Ok(mut stderr_log) = store.open_log(task_id, LogStream::Stderr) {
@@ -4175,13 +4189,8 @@ async fn run_completion_gate(
         }
     };
 
-    let output = match tokio::time::timeout(
-        Duration::from_secs(gate.timeout_sec),
-        child.wait_with_output(),
-    )
-    .await
-    {
-        Ok(Ok(output)) => output,
+    match tokio::time::timeout(Duration::from_secs(gate.timeout_sec), child.wait()).await {
+        Ok(Ok(status)) => status.code(),
         Ok(Err(err)) => {
             if let Ok(mut stderr_log) = store.open_log(task_id, LogStream::Stderr) {
                 let _ = writeln!(
@@ -4190,9 +4199,10 @@ async fn run_completion_gate(
                     gate.name
                 );
             }
-            return None;
+            None
         }
         Err(_) => {
+            let _ = child.kill().await;
             if let Ok(mut stderr_log) = store.open_log(task_id, LogStream::Stderr) {
                 let _ = writeln!(
                     stderr_log,
@@ -4200,20 +4210,9 @@ async fn run_completion_gate(
                     gate.name, gate.timeout_sec
                 );
             }
-            return None;
+            None
         }
-    };
-
-    if let Ok(mut stdout_log) = store.open_log(task_id, LogStream::Stdout) {
-        let _ = writeln!(stdout_log, "\n[completion gate:{}]", gate.name);
-        let _ = stdout_log.write_all(&output.stdout);
     }
-    if let Ok(mut stderr_log) = store.open_log(task_id, LogStream::Stderr) {
-        let _ = writeln!(stderr_log, "\n[completion gate:{}]", gate.name);
-        let _ = stderr_log.write_all(&output.stderr);
-    }
-
-    output.status.code()
 }
 
 fn map_exit_status(status: std::process::ExitStatus, canceled: bool) -> TaskResult {


### PR DESCRIPTION
## 概要

`run_completion_gate` が `wait_with_output()` で stdout/stderr を全てメモリにバッファリングしてからログに書き出していた問題を修正。verbose な gate コマンド（lint/test等）での大量メモリ消費とリアルタイム可視性の喪失を解消する。

Closes #59

## 変更内容

`Stdio::piped()` + `tokio::spawn` によるパイプ→ファイルのストリーミングコピー方式を採用:

- パイプで stdout/stderr をキャプチャし、8KiB チャンク単位でログファイルにストリーミング書き込み
- パイプ EOF 待ちによりバックグラウンドプロセスがゲートのライフサイクルから逃げることを防止
- `AbortHandle` でタイムアウト/エラー時にドレインタスクを確実に停止
- タイムアウトは `child.wait()` に適用し、ドレインには残り予算を適用（ディスクI/Oペナルティ回避）
- ドレインが残り予算を超過した場合はゲート失敗として扱う（旧 `wait_with_output()` と同じ挙動）
- タイムアウト時は `child.kill()` + `child.wait()` でゾンビプロセスを確実にreap

## テスト方法

- `cargo test run_completion_gate` — 既存テスト2件がパスすることを確認済み
- `cargo clippy` — warning なし