### PR TITLE
fix: ゲート成功後にもキャンセル状態を再チェックする

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3875,6 +3875,12 @@ impl TaskRunner for PlanTaskRunner {
                             }
                             break;
                         }
+                        // A fast gate may finish before the 100ms cancel poll
+                        // fires inside run_completion_gate, so re-check here.
+                        if cancel.is_canceled() {
+                            result = TaskResult::canceled();
+                            break;
+                        }
                     }
                 }
 


### PR DESCRIPTION
## 概要

- completion gate のキャンセル検出（100ms ポーリング）の競合を修正
- 短時間で終了するゲートで `child.wait()` が先に完了した場合、キャンセルが見逃され `Succeeded` として記録される問題に対処

## 変更内容

- ゲートループ内で、ゲート成功後にも `cancel.is_canceled()` を再チェックするガード条件を追加
- ポーリング粒度に依存せず、キャンセルを確実に反映

## テスト計画

- [x] `cargo check` 通過
- [x] `cargo clippy` 通過
- [x] 全テスト通過（`cargo test`）