### PR TITLE
feat: ゲート実行前のcommit + pre_gate hookをサポート

### DIFF
--- a/src/dry_run.rs
+++ b/src/dry_run.rs
@@ -272,6 +272,7 @@ mod tests {
             kind: None,
             output_files: None,
             auto_commit: true,
+            commit_before_gates: false,
             squash: false,
             codex: Some(crate::plan::CodexConfig {
                 prompt: "test prompt".to_string(),

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -21,6 +21,13 @@ impl GitManager {
         Ok(Self { repo })
     }
 
+    /// Open git repository at the given path (useful for worktree directories)
+    pub fn open_at(path: &std::path::Path) -> Result<Self> {
+        let repo = Repository::discover(path)
+            .with_context(|| format!("failed to open git repository at {}", path.display()))?;
+        Ok(Self { repo })
+    }
+
     /// Create a GitManager from an existing Repository (for testing)
     pub fn from_repo(repo: Repository) -> Self {
         Self { repo }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -127,6 +127,7 @@ fn resolve_hook_command(
         HookPoint::BeforeTask => t.before_task.as_ref(),
         HookPoint::AfterTask => t.after_task.as_ref(),
         HookPoint::OnFailure => t.on_failure.as_ref(),
+        HookPoint::PreGate => t.pre_gate.as_ref(),
         _ => None,
     });
 
@@ -141,6 +142,7 @@ fn resolve_hook_command(
             HookPoint::BeforeTask => g.before_task.as_ref(),
             HookPoint::AfterTask => g.after_task.as_ref(),
             HookPoint::OnFailure => g.on_failure.as_ref(),
+            HookPoint::PreGate => None,
         })
         .cloned()
 }
@@ -153,6 +155,7 @@ pub enum HookPoint {
     BeforeTask,
     AfterTask,
     OnFailure,
+    PreGate,
 }
 
 impl HookPoint {
@@ -163,6 +166,7 @@ impl HookPoint {
             HookPoint::BeforeTask => "before_task",
             HookPoint::AfterTask => "after_task",
             HookPoint::OnFailure => "on_failure",
+            HookPoint::PreGate => "pre_gate",
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3854,6 +3854,7 @@ impl TaskRunner for PlanTaskRunner {
                                         eprintln!(
                                             "task {task_id} commit_before_gates: committed {hash}"
                                         );
+                                        result.pre_gate_commit_hash = Some(hash);
                                     }
                                     Ok(_) => {}
                                     Err(err) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3318,6 +3318,7 @@ struct PlanTaskRunner {
     run_id: String,
     run_name: String,
     template_engine: Option<Arc<TemplateEngine>>,
+    git_commit_mutex: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl PlanTaskRunner {
@@ -3359,6 +3360,7 @@ impl PlanTaskRunner {
             run_id,
             run_name,
             template_engine,
+            git_commit_mutex: Arc::new(tokio::sync::Mutex::new(())),
         }
     }
 }
@@ -3382,6 +3384,7 @@ impl TaskRunner for PlanTaskRunner {
         let hook_run_id = self.run_id.clone();
         let hook_run_name = self.run_name.clone();
         let template_engine = self.template_engine.clone();
+        let git_commit_mutex = Arc::clone(&self.git_commit_mutex);
 
         Box::pin(async move {
             let Some(task) = tasks.get(&task_spec.id) else {
@@ -3840,9 +3843,10 @@ impl TaskRunner for PlanTaskRunner {
 
                 // commit_before_gates: commit changes and run pre_gate hook before gates
                 if result.status == TaskStatus::Succeeded && task.commit_before_gates {
-                    let commit_ok = match crate::git::GitManager::open_at(&task_ctx.cwd) {
-                        Ok(gm) => match gm.ensure_on_branch() {
-                            Ok(_) => {
+                    let commit_ok = {
+                        let _guard = git_commit_mutex.lock().await;
+                        match crate::git::GitManager::open_at(&task_ctx.cwd) {
+                            Ok(gm) => {
                                 let title = task.title.clone().unwrap_or_else(|| task_id.clone());
                                 let message = crate::git::generate_commit_message(
                                     &title,
@@ -3868,16 +3872,10 @@ impl TaskRunner for PlanTaskRunner {
                             }
                             Err(err) => {
                                 eprintln!(
-                                    "task {task_id} commit_before_gates: not on branch: {err:#}"
+                                    "task {task_id} commit_before_gates: git open failed: {err:#}"
                                 );
                                 false
                             }
-                        },
-                        Err(err) => {
-                            eprintln!(
-                                "task {task_id} commit_before_gates: git open failed: {err:#}"
-                            );
-                            false
                         }
                     };
 
@@ -3908,7 +3906,9 @@ impl TaskRunner for PlanTaskRunner {
                             eprintln!(
                                 "task {task_id} pre_gate hook failed, marking task as failed"
                             );
+                            let commit_hash = result.pre_gate_commit_hash.take();
                             result = TaskResult::failed(1);
+                            result.pre_gate_commit_hash = commit_hash;
                         }
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3858,7 +3858,12 @@ impl TaskRunner for PlanTaskRunner {
                                         eprintln!(
                                             "task {task_id} commit_before_gates: committed {hash}"
                                         );
-                                        result.pre_gate_commit_hash = Some(hash);
+                                        // Only track hash for squash when using shared cwd;
+                                        // worktree commits are on detached HEAD and not on the
+                                        // main branch, so they must not inflate squash counts.
+                                        if matches!(workdir, TaskWorkdir::Shared(_)) {
+                                            result.pre_gate_commit_hash = Some(hash);
+                                        }
                                         true
                                     }
                                     Ok(_) => true, // no changes to commit

--- a/src/main.rs
+++ b/src/main.rs
@@ -1071,6 +1071,7 @@ async fn handle_run(
             title: task.title.clone(),
             mode: task.mode,
             auto_commit: task.auto_commit,
+            commit_before_gates: task.commit_before_gates,
             squash: task.squash,
         })
         .collect();
@@ -1813,6 +1814,7 @@ async fn handle_retry(
             title: task.title.clone(),
             mode: task.mode,
             auto_commit: task.auto_commit,
+            commit_before_gates: task.commit_before_gates,
             squash: task.squash,
         });
     }
@@ -1839,6 +1841,7 @@ async fn handle_retry(
             title: task.title.clone(),
             mode: task.mode,
             auto_commit: task.auto_commit,
+            commit_before_gates: task.commit_before_gates,
             squash: task.squash,
         });
     }
@@ -3283,6 +3286,7 @@ async fn run_task_hook_with_events(
         HookPoint::OnFailure => "on_failure",
         HookPoint::BeforeRun => "before_run",
         HookPoint::AfterRun => "after_run",
+        HookPoint::PreGate => "pre_gate",
     };
     let _ = store.append_event(Event::HookStarted {
         hook_type: hook_type.to_string(),
@@ -3833,6 +3837,67 @@ impl TaskRunner for PlanTaskRunner {
                 };
 
                 let mut result = map_exit_status(status, cancel.is_canceled());
+
+                // commit_before_gates: commit changes and run pre_gate hook before gates
+                if result.status == TaskStatus::Succeeded && task.commit_before_gates {
+                    match crate::git::GitManager::open_at(&task_ctx.cwd) {
+                        Ok(gm) => {
+                            if gm.ensure_on_branch().is_ok() {
+                                let title = task.title.clone().unwrap_or_else(|| task_id.clone());
+                                let message = crate::git::generate_commit_message(
+                                    &title,
+                                    &task_id,
+                                    &format!("{:?}", task.mode),
+                                );
+                                match gm.create_commit(&message) {
+                                    Ok(hash) if !hash.is_empty() => {
+                                        eprintln!(
+                                            "task {task_id} commit_before_gates: committed {hash}"
+                                        );
+                                    }
+                                    Ok(_) => {}
+                                    Err(err) => {
+                                        eprintln!(
+                                            "task {task_id} commit_before_gates: commit failed: {err:#}"
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                        Err(err) => {
+                            eprintln!(
+                                "task {task_id} commit_before_gates: git open failed: {err:#}"
+                            );
+                        }
+                    }
+
+                    if !cancel.is_canceled() {
+                        let hook_ctx = HookContext {
+                            run_id: hook_run_id.clone(),
+                            run_name: hook_run_name.clone(),
+                            task_id: Some(task_id.clone()),
+                            task_title: task.title.clone(),
+                            status: Some("succeeded".to_string()),
+                            attempt: Some(attempt),
+                            exit_code: Some(0),
+                        };
+                        let hook_result = run_task_hook(
+                            HookPoint::PreGate,
+                            global_hooks.as_ref(),
+                            task.hooks.as_ref(),
+                            &hook_ctx,
+                            &task_ctx.env,
+                            &task_ctx.cwd,
+                        )
+                        .await;
+                        if hook_result.is_err() {
+                            eprintln!(
+                                "task {task_id} pre_gate hook failed, marking task as failed"
+                            );
+                            result = TaskResult::failed(1);
+                        }
+                    }
+                }
 
                 if result.status == TaskStatus::Succeeded && !task.skip_gates {
                     let gates = resolve_completion_gates(&task, default_gates.as_deref());
@@ -4544,6 +4609,7 @@ mod tests {
             }]),
             skip_gates: false,
             auto_commit: true,
+            commit_before_gates: false,
             squash: false,
             hooks: None,
         };
@@ -4592,6 +4658,7 @@ mod tests {
             completion_gates: None,
             skip_gates: false,
             auto_commit: true,
+            commit_before_gates: false,
             squash: false,
             hooks: None,
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -3840,9 +3840,9 @@ impl TaskRunner for PlanTaskRunner {
 
                 // commit_before_gates: commit changes and run pre_gate hook before gates
                 if result.status == TaskStatus::Succeeded && task.commit_before_gates {
-                    match crate::git::GitManager::open_at(&task_ctx.cwd) {
-                        Ok(gm) => {
-                            if gm.ensure_on_branch().is_ok() {
+                    let commit_ok = match crate::git::GitManager::open_at(&task_ctx.cwd) {
+                        Ok(gm) => match gm.ensure_on_branch() {
+                            Ok(_) => {
                                 let title = task.title.clone().unwrap_or_else(|| task_id.clone());
                                 let message = crate::git::generate_commit_message(
                                     &title,
@@ -3855,24 +3855,37 @@ impl TaskRunner for PlanTaskRunner {
                                             "task {task_id} commit_before_gates: committed {hash}"
                                         );
                                         result.pre_gate_commit_hash = Some(hash);
+                                        true
                                     }
-                                    Ok(_) => {}
+                                    Ok(_) => true, // no changes to commit
                                     Err(err) => {
                                         eprintln!(
                                             "task {task_id} commit_before_gates: commit failed: {err:#}"
                                         );
+                                        false
                                     }
                                 }
                             }
-                        }
+                            Err(err) => {
+                                eprintln!(
+                                    "task {task_id} commit_before_gates: not on branch: {err:#}"
+                                );
+                                false
+                            }
+                        },
                         Err(err) => {
                             eprintln!(
                                 "task {task_id} commit_before_gates: git open failed: {err:#}"
                             );
+                            false
                         }
+                    };
+
+                    if !commit_ok {
+                        result = TaskResult::failed(1);
                     }
 
-                    if !cancel.is_canceled() {
+                    if commit_ok && !cancel.is_canceled() {
                         let hook_ctx = HookContext {
                             run_id: hook_run_id.clone(),
                             run_name: hook_run_name.clone(),

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -565,6 +565,9 @@ pub struct TaskHooksConfig {
     pub after_task: Option<String>,
     /// Command to run when this task fails
     pub on_failure: Option<String>,
+    /// Command to run after commit but before completion gates.
+    /// Typically used for: git push + gh pr create.
+    pub pre_gate: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -645,6 +648,11 @@ pub struct Task {
     #[serde(default = "default_auto_commit")]
     #[schemars(default = "default_auto_commit")]
     pub auto_commit: bool,
+    /// Whether to create a git commit before running completion gates (default: false).
+    /// When true, the scheduler's post-task auto_commit is skipped to avoid double-commit.
+    /// Useful for PR-based review workflows where gates need committed code.
+    #[serde(default)]
+    pub commit_before_gates: bool,
     /// Whether this task should squash all previous commits into one
     /// Used for final integration/review tasks
     #[serde(default)]
@@ -1343,6 +1351,7 @@ mod tests {
                 completion_gates: None,
                 skip_gates: false,
                 auto_commit: true,
+                commit_before_gates: false,
                 squash: false,
                 hooks: None,
             }],
@@ -1399,6 +1408,7 @@ mod tests {
                 completion_gates: None,
                 skip_gates: false,
                 auto_commit: true,
+                commit_before_gates: false,
                 squash: false,
                 hooks: None,
             }],

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -21,6 +21,7 @@ pub struct TaskSpec {
     pub title: Option<String>,
     pub mode: crate::plan::TaskMode,
     pub auto_commit: bool,
+    pub commit_before_gates: bool,
     pub squash: bool,
 }
 
@@ -35,6 +36,7 @@ impl Default for TaskSpec {
             title: None,
             mode: crate::plan::TaskMode::default(),
             auto_commit: true,
+            commit_before_gates: false,
             squash: false,
         }
     }
@@ -624,6 +626,7 @@ fn handle_event(
             // Handle git commit if task succeeded and auto_commit is enabled
             if result.status == TaskStatus::Succeeded
                 && task_spec.auto_commit
+                && !task_spec.commit_before_gates
                 && matches!(
                     task_spec.mode,
                     crate::plan::TaskMode::Implement | crate::plan::TaskMode::Verify
@@ -741,6 +744,7 @@ mod tests {
             title: None,
             mode: TaskMode::Implement,
             auto_commit: false,
+            commit_before_gates: false,
             squash: false,
         }
     }
@@ -1083,6 +1087,7 @@ mod tests {
                 title: None,
                 mode: TaskMode::Implement,
                 auto_commit: false,
+                commit_before_gates: false,
                 squash: false,
             },
         );
@@ -1097,6 +1102,7 @@ mod tests {
                 title: None,
                 mode: TaskMode::Implement,
                 auto_commit: false,
+                commit_before_gates: false,
                 squash: false,
             },
         );

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -53,6 +53,8 @@ pub struct SchedulerOptions {
 pub struct TaskResult {
     pub status: TaskStatus,
     pub exit_code: Option<i32>,
+    /// Commit hash created by commit_before_gates (if any)
+    pub pre_gate_commit_hash: Option<String>,
 }
 
 impl TaskResult {
@@ -60,6 +62,7 @@ impl TaskResult {
         Self {
             status: TaskStatus::Succeeded,
             exit_code: Some(0),
+            pre_gate_commit_hash: None,
         }
     }
 
@@ -67,6 +70,7 @@ impl TaskResult {
         Self {
             status: TaskStatus::Failed,
             exit_code: Some(exit_code),
+            pre_gate_commit_hash: None,
         }
     }
 
@@ -74,6 +78,7 @@ impl TaskResult {
         Self {
             status: TaskStatus::Canceled,
             exit_code: None,
+            pre_gate_commit_hash: None,
         }
     }
 }
@@ -654,7 +659,7 @@ fn handle_event(
                                             commit_hashes.push((
                                                 task_spec.id.clone(),
                                                 commit_hash,
-                                                task_spec.title,
+                                                task_spec.title.clone(),
                                             ));
                                         }
                                     }
@@ -680,6 +685,11 @@ fn handle_event(
                         );
                     }
                 }
+            }
+
+            // Record commit hash from commit_before_gates
+            if let Some(hash) = &result.pre_gate_commit_hash {
+                commit_hashes.push((task_spec.id.clone(), hash.clone(), task_spec.title.clone()));
             }
 
             if let Some(record) = states.get_mut(&task_id) {

--- a/tests/condition_tests.rs
+++ b/tests/condition_tests.rs
@@ -114,6 +114,7 @@ async fn env_condition_equals_match() {
         title: None,
         mode: quedex::plan::TaskMode::default(),
         auto_commit: true,
+        commit_before_gates: false,
         squash: false,
     }];
 
@@ -142,6 +143,7 @@ async fn env_condition_equals_no_match() {
         title: None,
         mode: quedex::plan::TaskMode::default(),
         auto_commit: true,
+        commit_before_gates: false,
         squash: false,
     }];
 
@@ -171,6 +173,7 @@ async fn env_condition_equals_missing_var() {
         title: None,
         mode: quedex::plan::TaskMode::default(),
         auto_commit: true,
+        commit_before_gates: false,
         squash: false,
     }];
 
@@ -199,6 +202,7 @@ async fn env_condition_not_equals_match() {
         title: None,
         mode: quedex::plan::TaskMode::default(),
         auto_commit: true,
+        commit_before_gates: false,
         squash: false,
     }];
 
@@ -227,6 +231,7 @@ async fn env_condition_not_equals_no_match() {
         title: None,
         mode: quedex::plan::TaskMode::default(),
         auto_commit: true,
+        commit_before_gates: false,
         squash: false,
     }];
 
@@ -255,6 +260,7 @@ async fn env_condition_exists_true() {
         title: None,
         mode: quedex::plan::TaskMode::default(),
         auto_commit: true,
+        commit_before_gates: false,
         squash: false,
     }];
 
@@ -283,6 +289,7 @@ async fn env_condition_exists_false() {
         title: None,
         mode: quedex::plan::TaskMode::default(),
         auto_commit: true,
+        commit_before_gates: false,
         squash: false,
     }];
 
@@ -309,6 +316,7 @@ async fn task_condition_succeeded_match() {
             title: None,
             mode: quedex::plan::TaskMode::default(),
             auto_commit: true,
+            commit_before_gates: false,
             squash: false,
         },
         TaskSpec {
@@ -323,6 +331,7 @@ async fn task_condition_succeeded_match() {
             title: None,
             mode: quedex::plan::TaskMode::default(),
             auto_commit: true,
+            commit_before_gates: false,
             squash: false,
         },
     ];
@@ -348,6 +357,7 @@ async fn task_condition_failed_match() {
             title: None,
             mode: quedex::plan::TaskMode::default(),
             auto_commit: true,
+            commit_before_gates: false,
             squash: false,
         },
         TaskSpec {
@@ -362,6 +372,7 @@ async fn task_condition_failed_match() {
             title: None,
             mode: quedex::plan::TaskMode::default(),
             auto_commit: true,
+            commit_before_gates: false,
             squash: false,
         },
     ];
@@ -387,6 +398,7 @@ async fn task_condition_failed_no_match_when_succeeded() {
             title: None,
             mode: quedex::plan::TaskMode::default(),
             auto_commit: true,
+            commit_before_gates: false,
             squash: false,
         },
         TaskSpec {
@@ -401,6 +413,7 @@ async fn task_condition_failed_no_match_when_succeeded() {
             title: None,
             mode: quedex::plan::TaskMode::default(),
             auto_commit: true,
+            commit_before_gates: false,
             squash: false,
         },
     ];
@@ -434,6 +447,7 @@ async fn condition_skip_does_not_propagate_as_failure() {
             title: None,
             mode: quedex::plan::TaskMode::default(),
             auto_commit: true,
+            commit_before_gates: false,
             squash: false,
         },
         TaskSpec {
@@ -445,6 +459,7 @@ async fn condition_skip_does_not_propagate_as_failure() {
             title: None,
             mode: quedex::plan::TaskMode::default(),
             auto_commit: true,
+            commit_before_gates: false,
             squash: false,
         },
     ];
@@ -477,6 +492,7 @@ async fn dependency_failure_skip_does_propagate() {
             title: None,
             mode: quedex::plan::TaskMode::default(),
             auto_commit: true,
+            commit_before_gates: false,
             squash: false,
         },
         TaskSpec {
@@ -488,6 +504,7 @@ async fn dependency_failure_skip_does_propagate() {
             title: None,
             mode: quedex::plan::TaskMode::default(),
             auto_commit: true,
+            commit_before_gates: false,
             squash: false,
         },
     ];
@@ -543,6 +560,7 @@ fn plan_rejects_condition_referencing_nonexistent_task() {
         completion_gates: None,
         skip_gates: false,
         auto_commit: true,
+        commit_before_gates: false,
         squash: false,
         condition: Some(TaskCondition::TaskResult(TaskResultCondition {
             task: "nonexistent".to_string(),
@@ -604,6 +622,7 @@ fn plan_rejects_condition_referencing_self() {
         completion_gates: None,
         skip_gates: false,
         auto_commit: true,
+        commit_before_gates: false,
         squash: false,
         condition: Some(TaskCondition::TaskResult(TaskResultCondition {
             task: "main".to_string(),

--- a/tests/dry_run_tests.rs
+++ b/tests/dry_run_tests.rs
@@ -63,6 +63,7 @@ fn create_task(id: &str, deps: Vec<&str>, locks: Vec<&str>) -> Task {
         completion_gates: None,
         skip_gates: false,
         auto_commit: true,
+        commit_before_gates: false,
         squash: false,
         hooks: None,
     }

--- a/tests/git_tests.rs
+++ b/tests/git_tests.rs
@@ -81,6 +81,85 @@ fn test_task_json_parsing() {
     assert!(!task.squash);
 }
 
+#[test]
+fn test_commit_before_gates_defaults_to_false() {
+    let task_json = r#"{
+        "id": "task-1",
+        "mode": "implement",
+        "codex": { "prompt": "test" }
+    }"#;
+
+    let task: quedex::plan::Task = serde_json::from_str(task_json).unwrap();
+    assert!(!task.commit_before_gates);
+}
+
+#[test]
+fn test_commit_before_gates_can_be_enabled() {
+    let task_json = r#"{
+        "id": "task-1",
+        "mode": "implement",
+        "commit_before_gates": true,
+        "codex": { "prompt": "test" }
+    }"#;
+
+    let task: quedex::plan::Task = serde_json::from_str(task_json).unwrap();
+    assert!(task.commit_before_gates);
+}
+
+#[test]
+fn test_pre_gate_hook_parsing() {
+    let task_json = r#"{
+        "id": "task-1",
+        "mode": "implement",
+        "commit_before_gates": true,
+        "hooks": {
+            "pre_gate": "git push -u origin HEAD"
+        },
+        "codex": { "prompt": "test" }
+    }"#;
+
+    let task: quedex::plan::Task = serde_json::from_str(task_json).unwrap();
+    assert!(task.commit_before_gates);
+    assert_eq!(
+        task.hooks.as_ref().unwrap().pre_gate.as_deref(),
+        Some("git push -u origin HEAD")
+    );
+}
+
+#[test]
+fn test_commit_before_gates_full_plan_yaml() {
+    let yaml = r#"
+version: 1
+run:
+  name: pr-review-test
+tasks:
+  - id: impl
+    mode: implement
+    commit_before_gates: true
+    retry_count: 2
+    retry_strategy:
+      inject_error_context: true
+    hooks:
+      pre_gate: "git push -u origin HEAD"
+    completion_gates:
+      - name: pr-approval
+        command: "exit 0"
+        timeout_sec: 60
+    codex:
+      prompt: "implement feature"
+"#;
+
+    let plan: quedex::plan::Plan = serde_yaml::from_str(yaml).unwrap();
+    let task = &plan.tasks[0];
+    assert!(task.commit_before_gates);
+    assert_eq!(
+        task.hooks.as_ref().unwrap().pre_gate.as_deref(),
+        Some("git push -u origin HEAD")
+    );
+    assert!(task.completion_gates.is_some());
+    assert_eq!(task.retry_count, 2);
+}
+
 // Integration tests for GitManager operations
 // These tests create temporary git repositories to test actual git operations
 
@@ -208,5 +287,19 @@ mod git_integration_tests {
             .expect("Failed to list commits");
         assert_eq!(commits.len(), 2, "Should have 2 commits after squash");
         assert_eq!(commits[0].summary, "Squashed commit");
+    }
+
+    #[test]
+    fn test_git_manager_open_at() {
+        let (_temp_dir, repo_path) = create_temp_git_repo();
+
+        let manager = quedex::git::GitManager::open_at(&repo_path).expect("Failed to open_at repo");
+        assert!(manager.ensure_on_branch().is_ok());
+    }
+
+    #[test]
+    fn test_git_manager_open_at_nonexistent() {
+        let result = quedex::git::GitManager::open_at(std::path::Path::new("/nonexistent/path"));
+        assert!(result.is_err());
     }
 }

--- a/tests/plan_validation_tests.rs
+++ b/tests/plan_validation_tests.rs
@@ -36,6 +36,7 @@ fn codex_task(id: &str, deps: Vec<&str>) -> Task {
         completion_gates: None,
         skip_gates: false,
         auto_commit: true,
+        commit_before_gates: false,
         squash: false,
         hooks: None,
     }
@@ -72,6 +73,7 @@ fn opencode_task(id: &str, deps: Vec<&str>) -> Task {
         completion_gates: None,
         skip_gates: false,
         auto_commit: true,
+        commit_before_gates: false,
         squash: false,
         hooks: None,
     }
@@ -150,6 +152,7 @@ fn plan_rejects_empty_codex_prompt() {
         completion_gates: None,
         skip_gates: false,
         auto_commit: true,
+        commit_before_gates: false,
         squash: false,
         hooks: None,
     };
@@ -189,6 +192,7 @@ fn plan_rejects_empty_claude_code_prompt() {
         completion_gates: None,
         skip_gates: false,
         auto_commit: true,
+        commit_before_gates: false,
         squash: false,
         hooks: None,
     };
@@ -235,6 +239,7 @@ fn plan_rejects_multiple_runner_configs() {
         completion_gates: None,
         skip_gates: false,
         auto_commit: true,
+        commit_before_gates: false,
         squash: false,
         hooks: None,
     };
@@ -274,6 +279,7 @@ fn plan_accepts_valid_claude_code_task() {
         completion_gates: None,
         skip_gates: false,
         auto_commit: true,
+        commit_before_gates: false,
         squash: false,
         hooks: None,
     };
@@ -316,6 +322,7 @@ fn plan_rejects_kind_mismatch_claude_code() {
         completion_gates: None,
         skip_gates: false,
         auto_commit: true,
+        commit_before_gates: false,
         squash: false,
         hooks: None,
     };
@@ -355,6 +362,7 @@ fn plan_rejects_empty_opencode_prompt() {
         completion_gates: None,
         skip_gates: false,
         auto_commit: true,
+        commit_before_gates: false,
         squash: false,
         hooks: None,
     };
@@ -412,6 +420,7 @@ fn plan_accepts_valid_opencode_task() {
         completion_gates: None,
         skip_gates: false,
         auto_commit: true,
+        commit_before_gates: false,
         squash: false,
         hooks: None,
     };
@@ -454,6 +463,7 @@ fn plan_rejects_kind_mismatch_opencode() {
         completion_gates: None,
         skip_gates: false,
         auto_commit: true,
+        commit_before_gates: false,
         squash: false,
         hooks: None,
     };
@@ -497,6 +507,7 @@ fn plan_rejects_multiple_runner_configs_with_opencode() {
         completion_gates: None,
         skip_gates: false,
         auto_commit: true,
+        commit_before_gates: false,
         squash: false,
         hooks: None,
     };

--- a/tests/scheduler_tests.rs
+++ b/tests/scheduler_tests.rs
@@ -193,6 +193,7 @@ async fn scheduler_resolves_deps_in_order() {
             title: None,
             mode: quedex::plan::TaskMode::default(),
             auto_commit: true,
+            commit_before_gates: false,
             squash: false,
         },
         TaskSpec {
@@ -204,6 +205,7 @@ async fn scheduler_resolves_deps_in_order() {
             title: None,
             mode: quedex::plan::TaskMode::default(),
             auto_commit: true,
+            commit_before_gates: false,
             squash: false,
         },
         TaskSpec {
@@ -215,6 +217,7 @@ async fn scheduler_resolves_deps_in_order() {
             title: None,
             mode: quedex::plan::TaskMode::default(),
             auto_commit: true,
+            commit_before_gates: false,
             squash: false,
         },
     ];
@@ -277,6 +280,7 @@ async fn scheduler_enforces_lock_exclusion() {
             title: None,
             mode: quedex::plan::TaskMode::default(),
             auto_commit: true,
+            commit_before_gates: false,
             squash: false,
         },
         TaskSpec {
@@ -288,6 +292,7 @@ async fn scheduler_enforces_lock_exclusion() {
             title: None,
             mode: quedex::plan::TaskMode::default(),
             auto_commit: true,
+            commit_before_gates: false,
             squash: false,
         },
         TaskSpec {
@@ -299,6 +304,7 @@ async fn scheduler_enforces_lock_exclusion() {
             title: None,
             mode: quedex::plan::TaskMode::default(),
             auto_commit: true,
+            commit_before_gates: false,
             squash: false,
         },
     ];
@@ -359,6 +365,7 @@ async fn scheduler_skips_pending_tasks_on_fail_fast() {
             title: None,
             mode: quedex::plan::TaskMode::default(),
             auto_commit: true,
+            commit_before_gates: false,
             squash: false,
         },
         TaskSpec {
@@ -370,6 +377,7 @@ async fn scheduler_skips_pending_tasks_on_fail_fast() {
             title: None,
             mode: quedex::plan::TaskMode::default(),
             auto_commit: true,
+            commit_before_gates: false,
             squash: false,
         },
         TaskSpec {
@@ -381,6 +389,7 @@ async fn scheduler_skips_pending_tasks_on_fail_fast() {
             title: None,
             mode: quedex::plan::TaskMode::default(),
             auto_commit: true,
+            commit_before_gates: false,
             squash: false,
         },
     ];
@@ -456,6 +465,7 @@ async fn scheduler_respects_max_concurrency() {
             title: None,
             mode: quedex::plan::TaskMode::default(),
             auto_commit: true,
+            commit_before_gates: false,
             squash: false,
         },
         TaskSpec {
@@ -467,6 +477,7 @@ async fn scheduler_respects_max_concurrency() {
             title: None,
             mode: quedex::plan::TaskMode::default(),
             auto_commit: true,
+            commit_before_gates: false,
             squash: false,
         },
         TaskSpec {
@@ -478,6 +489,7 @@ async fn scheduler_respects_max_concurrency() {
             title: None,
             mode: quedex::plan::TaskMode::default(),
             auto_commit: true,
+            commit_before_gates: false,
             squash: false,
         },
         TaskSpec {
@@ -489,6 +501,7 @@ async fn scheduler_respects_max_concurrency() {
             title: None,
             mode: quedex::plan::TaskMode::default(),
             auto_commit: true,
+            commit_before_gates: false,
             squash: false,
         },
     ];


### PR DESCRIPTION
## 概要

PR Review Gate ワークフローを実現するため、リトライループ内で completion gate 実行前に git commit と pre_gate hook を実行する機能を追加。

これにより、ランナーの変更を PR 化し、人間のレビュー（👍リアクションやレビューコメント）を挟んでからマージするワークフローが plan.yaml の設定だけで実現可能になる。

## 変更内容

- `Task` に `commit_before_gates` フィールドを追加（デフォルト: false）
- `TaskHooksConfig` に `pre_gate` フックを追加（commit 後・ゲート前に実行）
- `HookPoint` に `PreGate` バリアントを追加
- `GitManager` に `open_at(path)` メソッドを追加（worktree 対応）
- `commit_before_gates: true` 時はスケジューラ側の auto_commit をスキップ（二重 commit 防止）

## 使い方

```yaml
tasks:
  - id: implement-feature
    mode: implement
    commit_before_gates: true
    retry_count: 3
    retry_strategy:
      inject_error_context: true
    hooks:
      pre_gate: |
        git push -u origin HEAD
        gh pr create --title "$QUEDEX_TASK_ID" --body "auto" 2>/dev/null || true
    completion_gates:
      - name: pr-approval
        command: |
          PR=$(gh pr list --head "$(git branch --show-current)" --json number -q '.[0].number')
          # 👍 があれば承認
          THUMBSUP=$(gh api "repos/{owner}/{repo}/issues/$PR/reactions" --jq '[.[] | select(.content=="+1")] | length')
          [ "$THUMBSUP" -gt 0 ] && exit 0
          # 未解決のレビューコメントがあれば修正要求
          COMMENTS=$(gh api "repos/{owner}/{repo}/pulls/$PR/comments" --jq 'length')
          if [ "$COMMENTS" -gt 0 ]; then
            echo "=== Review comments ===" >&2
            gh api "repos/{owner}/{repo}/pulls/$PR/comments" \
              --jq '.[] | "[\(.path):\(.line)] \(.body)"' >&2
            exit 1
          fi
          sleep 30
        timeout_sec: 3600
```

## フロー

```
retry loop {
  ランナー実行 → 成功
  → [commit_before_gates] git commit
  → [pre_gate hook] git push + gh pr create
  → [completion_gate] PRリアクション/レビューチェック
  ├─ 👍 → gate通過 → タスク成功
  └─ レビューコメントあり → gate失敗（コメントをstderrに出力）
       → inject_error_context でコメントをプロンプトに注入
       → リトライ（ランナーが修正）
}
```

## テスト方法

- `cargo build` ✅
- `cargo test` ✅ (全 231 テスト通過)
- `cargo clippy` ✅ (警告なし)
- `cargo run -- schema` で新フィールドが JSON Schema に反映されていることを確認 ✅